### PR TITLE
XRC resource references are optional

### DIFF
--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -2964,7 +2964,7 @@ type CompositeResourceClaim implements KubernetesResource {
 type CompositeResourceClaimSpec {
   composition: Composition @goField(forceResolver: true)
   compositionSelector: LabelSelector
-  resource: CompositeResource! @goField(forceResolver: true)
+  resource: CompositeResource @goField(forceResolver: true)
   writesConnectionSecretTo: Secret @goField(forceResolver: true)
 }
 
@@ -4516,14 +4516,11 @@ func (ec *executionContext) _CompositeResourceClaimSpec_resource(ctx context.Con
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*model.CompositeResource)
 	fc.Result = res
-	return ec.marshalNCompositeResource2ᚖgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐCompositeResource(ctx, field.Selections, res)
+	return ec.marshalOCompositeResource2ᚖgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐCompositeResource(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CompositeResourceClaimSpec_writesConnectionSecretTo(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceClaimSpec) (ret graphql.Marshaler) {
@@ -14409,9 +14406,6 @@ func (ec *executionContext) _CompositeResourceClaimSpec(ctx context.Context, sel
 					}
 				}()
 				res = ec._CompositeResourceClaimSpec_resource(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			})
 		case "writesConnectionSecretTo":
@@ -17156,16 +17150,6 @@ func (ec *executionContext) marshalNCompositeResource2githubᚗcomᚋupboundᚋx
 	return ec._CompositeResource(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNCompositeResource2ᚖgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐCompositeResource(ctx context.Context, sel ast.SelectionSet, v *model.CompositeResource) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec._CompositeResource(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNCompositeResourceClaim2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐCompositeResourceClaim(ctx context.Context, sel ast.SelectionSet, v model.CompositeResourceClaim) graphql.Marshaler {
 	return ec._CompositeResourceClaim(ctx, sel, &v)
 }
@@ -18019,6 +18003,13 @@ func (ec *executionContext) marshalOCompositeResource2ᚕgithubᚗcomᚋupbound�
 	}
 	wg.Wait()
 	return ret
+}
+
+func (ec *executionContext) marshalOCompositeResource2ᚖgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐCompositeResource(ctx context.Context, sel ast.SelectionSet, v *model.CompositeResource) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CompositeResource(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOCompositeResourceClaim2ᚕgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐCompositeResourceClaimᚄ(ctx context.Context, sel ast.SelectionSet, v []model.CompositeResourceClaim) graphql.Marshaler {

--- a/schema/composite.gql
+++ b/schema/composite.gql
@@ -53,7 +53,7 @@ type CompositeResourceClaim implements KubernetesResource {
 type CompositeResourceClaimSpec {
   composition: Composition @goField(forceResolver: true)
   compositionSelector: LabelSelector
-  resource: CompositeResource! @goField(forceResolver: true)
+  resource: CompositeResource @goField(forceResolver: true)
   writesConnectionSecretTo: Secret @goField(forceResolver: true)
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
A composite resource claim may _technically_ exist with an unset reference to a composite resource. Interestingly we probably want this to be a required field - a claim without a resourceRef will sit around doing nothing until someone fixes it. Unfortunately this is now part of the surface area of our v1 API and thus it will remain optional.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
It has not - this type is currently unused.

[contribution process]: https://git.io/fj2m9
