### PR TITLE
Fix owner ref conversion from unstructured

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -107,7 +107,7 @@ func main() {
 		clients.DoNotCache(noCache),
 		clients.WithLogger(log),
 	)
-	rt.Handle("/query", handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: resolvers.New(ca, s)})))
+	rt.Handle("/query", handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: resolvers.New(ca)})))
 
 	if *play {
 		rt.Handle("/", playground.Handler("GraphQL playground", "/query"))

--- a/internal/graph/resolvers/root.go
+++ b/internal/graph/resolvers/root.go
@@ -12,21 +12,14 @@ type ClientCache interface {
 	Get(token string, o ...clients.GetOption) (client.Client, error)
 }
 
-// ObjectConvertor converts an object to a different version. It's a subset of
-// the Kubernetes runtime.ObjectConvertor interface.
-type ObjectConvertor interface {
-	Convert(in, out, context interface{}) error
-}
-
 // The Root resolver.
 type Root struct {
-	clients   ClientCache
-	converter ObjectConvertor
+	clients ClientCache
 }
 
 // New returns a new root resolver.
-func New(cc ClientCache, oc ObjectConvertor) *Root {
-	return &Root{clients: cc, converter: oc}
+func New(cc ClientCache) *Root {
+	return &Root{clients: cc}
 }
 
 // Query resolves GraphQL queries.
@@ -36,7 +29,7 @@ func (r *Root) Query() generated.QueryResolver {
 
 // ObjectMeta resolves properties of the ObjectMeta GraphQL type.
 func (r *Root) ObjectMeta() generated.ObjectMetaResolver {
-	return &objectMetaResolver{clients: r.clients, converter: r.converter}
+	return &objectMetaResolver{clients: r.clients}
 }
 
 // Secret resolves properties of the Secret GraphQL type.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I noticed the existing method seemed to be omitting the GVK for whatever reason. The previous ObjectConverter was calling the DefaultUnstructuredConverter anyhow so I've just cut to the chase and followed it by copying the GVK manually.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
