### PR TITLE
Add an id for all distinct Kubernetes resources

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -28,10 +28,7 @@ autobind:
 models:
   ID:
     model:
-      - github.com/99designs/gqlgen/graphql.ID
-      - github.com/99designs/gqlgen/graphql.Int
-      - github.com/99designs/gqlgen/graphql.Int64
-      - github.com/99designs/gqlgen/graphql.Int32
+      - github.com/upbound/xgql/internal/graph/model.ReferenceID
   Int:
     model:
       - github.com/99designs/gqlgen/graphql.Int

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -73,6 +73,7 @@ type ComplexityRoot struct {
 	CompositeResource struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -83,6 +84,7 @@ type ComplexityRoot struct {
 	CompositeResourceClaim struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -125,6 +127,7 @@ type ComplexityRoot struct {
 		DefinedCompositeResourceClaims func(childComplexity int, limit *int, version *string, namespace *string) int
 		DefinedCompositeResources      func(childComplexity int, limit *int, version *string) int
 		Events                         func(childComplexity int, limit *int) int
+		ID                             func(childComplexity int) int
 		Kind                           func(childComplexity int) int
 		Metadata                       func(childComplexity int) int
 		Raw                            func(childComplexity int) int
@@ -193,6 +196,7 @@ type ComplexityRoot struct {
 	Composition struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -225,6 +229,7 @@ type ComplexityRoot struct {
 	Configuration struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -241,6 +246,7 @@ type ComplexityRoot struct {
 	ConfigurationRevision struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -290,6 +296,7 @@ type ComplexityRoot struct {
 		APIVersion       func(childComplexity int) int
 		DefinedResources func(childComplexity int, limit *int, version *string) int
 		Events           func(childComplexity int, limit *int) int
+		ID               func(childComplexity int) int
 		Kind             func(childComplexity int) int
 		Metadata         func(childComplexity int) int
 		Raw              func(childComplexity int) int
@@ -330,6 +337,7 @@ type ComplexityRoot struct {
 		APIVersion     func(childComplexity int) int
 		Count          func(childComplexity int) int
 		FirstTime      func(childComplexity int) int
+		ID             func(childComplexity int) int
 		InvolvedObject func(childComplexity int) int
 		Kind           func(childComplexity int) int
 		LastTime       func(childComplexity int) int
@@ -353,6 +361,7 @@ type ComplexityRoot struct {
 	GenericResource struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -370,6 +379,7 @@ type ComplexityRoot struct {
 	ManagedResource struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -422,6 +432,7 @@ type ComplexityRoot struct {
 	Provider struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -433,6 +444,7 @@ type ComplexityRoot struct {
 	ProviderConfig struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -452,6 +464,7 @@ type ComplexityRoot struct {
 	ProviderRevision struct {
 		APIVersion func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -508,6 +521,7 @@ type ComplexityRoot struct {
 		APIVersion func(childComplexity int) int
 		Data       func(childComplexity int) int
 		Events     func(childComplexity int, limit *int) int
+		ID         func(childComplexity int) int
 		Kind       func(childComplexity int) int
 		Metadata   func(childComplexity int) int
 		Raw        func(childComplexity int) int
@@ -655,6 +669,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CompositeResource.Events(childComplexity, args["limit"].(*int)), true
 
+	case "CompositeResource.id":
+		if e.complexity.CompositeResource.ID == nil {
+			break
+		}
+
+		return e.complexity.CompositeResource.ID(childComplexity), true
+
 	case "CompositeResource.kind":
 		if e.complexity.CompositeResource.Kind == nil {
 			break
@@ -708,6 +729,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CompositeResourceClaim.Events(childComplexity, args["limit"].(*int)), true
+
+	case "CompositeResourceClaim.id":
+		if e.complexity.CompositeResourceClaim.ID == nil {
+			break
+		}
+
+		return e.complexity.CompositeResourceClaim.ID(childComplexity), true
 
 	case "CompositeResourceClaim.kind":
 		if e.complexity.CompositeResourceClaim.Kind == nil {
@@ -870,6 +898,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CompositeResourceDefinition.Events(childComplexity, args["limit"].(*int)), true
+
+	case "CompositeResourceDefinition.id":
+		if e.complexity.CompositeResourceDefinition.ID == nil {
+			break
+		}
+
+		return e.complexity.CompositeResourceDefinition.ID(childComplexity), true
 
 	case "CompositeResourceDefinition.kind":
 		if e.complexity.CompositeResourceDefinition.Kind == nil {
@@ -1147,6 +1182,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Composition.Events(childComplexity, args["limit"].(*int)), true
 
+	case "Composition.id":
+		if e.complexity.Composition.ID == nil {
+			break
+		}
+
+		return e.complexity.Composition.ID(childComplexity), true
+
 	case "Composition.kind":
 		if e.complexity.Composition.Kind == nil {
 			break
@@ -1271,6 +1313,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Configuration.Events(childComplexity, args["limit"].(*int)), true
 
+	case "Configuration.id":
+		if e.complexity.Configuration.ID == nil {
+			break
+		}
+
+		return e.complexity.Configuration.ID(childComplexity), true
+
 	case "Configuration.kind":
 		if e.complexity.Configuration.Kind == nil {
 			break
@@ -1350,6 +1399,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ConfigurationRevision.Events(childComplexity, args["limit"].(*int)), true
+
+	case "ConfigurationRevision.id":
+		if e.complexity.ConfigurationRevision.ID == nil {
+			break
+		}
+
+		return e.complexity.ConfigurationRevision.ID(childComplexity), true
 
 	case "ConfigurationRevision.kind":
 		if e.complexity.ConfigurationRevision.Kind == nil {
@@ -1583,6 +1639,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CustomResourceDefinition.Events(childComplexity, args["limit"].(*int)), true
 
+	case "CustomResourceDefinition.id":
+		if e.complexity.CustomResourceDefinition.ID == nil {
+			break
+		}
+
+		return e.complexity.CustomResourceDefinition.ID(childComplexity), true
+
 	case "CustomResourceDefinition.kind":
 		if e.complexity.CustomResourceDefinition.Kind == nil {
 			break
@@ -1737,6 +1800,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Event.FirstTime(childComplexity), true
 
+	case "Event.id":
+		if e.complexity.Event.ID == nil {
+			break
+		}
+
+		return e.complexity.Event.ID(childComplexity), true
+
 	case "Event.involvedObject":
 		if e.complexity.Event.InvolvedObject == nil {
 			break
@@ -1840,6 +1910,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.GenericResource.Events(childComplexity, args["limit"].(*int)), true
 
+	case "GenericResource.id":
+		if e.complexity.GenericResource.ID == nil {
+			break
+		}
+
+		return e.complexity.GenericResource.ID(childComplexity), true
+
 	case "GenericResource.kind":
 		if e.complexity.GenericResource.Kind == nil {
 			break
@@ -1900,6 +1977,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ManagedResource.Events(childComplexity, args["limit"].(*int)), true
+
+	case "ManagedResource.id":
+		if e.complexity.ManagedResource.ID == nil {
+			break
+		}
+
+		return e.complexity.ManagedResource.ID(childComplexity), true
 
 	case "ManagedResource.kind":
 		if e.complexity.ManagedResource.Kind == nil {
@@ -2128,6 +2212,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Provider.Events(childComplexity, args["limit"].(*int)), true
 
+	case "Provider.id":
+		if e.complexity.Provider.ID == nil {
+			break
+		}
+
+		return e.complexity.Provider.ID(childComplexity), true
+
 	case "Provider.kind":
 		if e.complexity.Provider.Kind == nil {
 			break
@@ -2193,6 +2284,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProviderConfig.Events(childComplexity, args["limit"].(*int)), true
+
+	case "ProviderConfig.id":
+		if e.complexity.ProviderConfig.ID == nil {
+			break
+		}
+
+		return e.complexity.ProviderConfig.ID(childComplexity), true
 
 	case "ProviderConfig.kind":
 		if e.complexity.ProviderConfig.Kind == nil {
@@ -2268,6 +2366,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProviderRevision.Events(childComplexity, args["limit"].(*int)), true
+
+	case "ProviderRevision.id":
+		if e.complexity.ProviderRevision.ID == nil {
+			break
+		}
+
+		return e.complexity.ProviderRevision.ID(childComplexity), true
 
 	case "ProviderRevision.kind":
 		if e.complexity.ProviderRevision.Kind == nil {
@@ -2544,6 +2649,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Secret.Events(childComplexity, args["limit"].(*int)), true
 
+	case "Secret.id":
+		if e.complexity.Secret.ID == nil {
+			break
+		}
+
+		return e.complexity.Secret.ID(childComplexity), true
+
 	case "Secret.kind":
 		if e.complexity.Secret.Kind == nil {
 			break
@@ -2643,7 +2755,9 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
-	{Name: "schema/apiextensions.gql", Input: `type CompositeResourceDefinition implements KubernetesResource {
+	{Name: "schema/apiextensions.gql", Input: `type CompositeResourceDefinition implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2712,7 +2826,9 @@ type TypeReference {
   kind: String!
 }
 
-type Composition implements KubernetesResource {
+type Composition implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2740,7 +2856,13 @@ type CompositionStatus implements ConditionedStatus {
 scalar Map
 scalar JSONObject
 
+interface Node {
+  id: ID!
+}
+
 interface KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2759,7 +2881,9 @@ type KubernetesResourceConnection {
   count: Int!
 }
 
-type GenericResource implements KubernetesResource {
+type GenericResource implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2774,7 +2898,7 @@ type ObjectMeta {
   name: String!
   generateName: String
   namespace: String
-  uid: ID!
+  uid: String!
   resourceVersion: String!
   generation: Int!
   creationTime: Time!
@@ -2827,7 +2951,13 @@ type LabelSelector {
   matchLabels: Map
 }
 
-type Event {
+# NOTE(negz): Event does not implement KubernetesResource simply because an
+# event does not have events. We might consider creating a distinct
+# InvolvedObject interface (or something like that) for the events field.
+
+type Event implements Node {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2852,7 +2982,9 @@ enum EventType {
   Warning
 }
 
-type Secret implements KubernetesResource {
+type Secret implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2868,7 +3000,9 @@ type SecretConnection {
   count: Int!
 }
 
-type CustomResourceDefinition implements KubernetesResource {
+type CustomResourceDefinition implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2909,7 +3043,9 @@ type CustomResourceValidation {
 type CustomResourceDefinitionStatus implements ConditionedStatus {
   conditions: [Condition!]
 }`, BuiltIn: false},
-	{Name: "schema/composite.gql", Input: `type CompositeResource implements KubernetesResource {
+	{Name: "schema/composite.gql", Input: `type CompositeResource implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2949,7 +3085,9 @@ type CompositeResourceConnectionDetails {
   lastPublishedTime: Time
 }
 
-type CompositeResourceClaim implements KubernetesResource {
+type CompositeResourceClaim implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -2977,7 +3115,9 @@ type CompositeResourceClaimConnectionDetails {
   lastPublishedTime: Time
 }
 `, BuiltIn: false},
-	{Name: "schema/configuration.gql", Input: `type Configuration implements KubernetesResource {
+	{Name: "schema/configuration.gql", Input: `type Configuration implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -3017,7 +3157,9 @@ type ConfigurationStatus implements ConditionedStatus {
   currentIdentifier: String
 }
 
-type ConfigurationRevision implements KubernetesResource {
+type ConfigurationRevision implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -3063,7 +3205,9 @@ type ConfigurationRevisionStatus implements ConditionedStatus {
 
 directive @goField(forceResolver: Boolean, name: String) on INPUT_FIELD_DEFINITION
     | FIELD_DEFINITION`, BuiltIn: false},
-	{Name: "schema/managed.gql", Input: `type ManagedResource implements KubernetesResource {
+	{Name: "schema/managed.gql", Input: `type ManagedResource implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -3107,7 +3251,9 @@ enum PackageRevisionDesiredState {
 }
 
 `, BuiltIn: false},
-	{Name: "schema/provider.gql", Input: `type Provider implements KubernetesResource {
+	{Name: "schema/provider.gql", Input: `type Provider implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -3147,7 +3293,9 @@ type ProviderStatus implements ConditionedStatus {
   currentIdentifier: String
 }
 
-type ProviderRevision implements KubernetesResource {
+type ProviderRevision implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -3185,7 +3333,9 @@ type ProviderRevisionStatus implements ConditionedStatus {
   objects(limit: Int): KubernetesResourceConnection! @goField(forceResolver: true)
 }
 `, BuiltIn: false},
-	{Name: "schema/providerconfig.gql", Input: `type ProviderConfig implements KubernetesResource {
+	{Name: "schema/providerconfig.gql", Input: `type ProviderConfig implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -3824,6 +3974,41 @@ func (ec *executionContext) _ComposedResourceConnection_count(ctx context.Contex
 	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _CompositeResource_id(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResource) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CompositeResource",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _CompositeResource_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResource) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -4074,6 +4259,41 @@ func (ec *executionContext) _CompositeResource_events(ctx context.Context, field
 	res := resTmp.(*model.EventConnection)
 	fc.Result = res
 	return ec.marshalNEventConnection2ᚖgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐEventConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CompositeResourceClaim_id(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceClaim) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CompositeResourceClaim",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CompositeResourceClaim_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceClaim) (ret graphql.Marshaler) {
@@ -4716,6 +4936,41 @@ func (ec *executionContext) _CompositeResourceConnectionDetails_lastPublishedTim
 	res := resTmp.(*time.Time)
 	fc.Result = res
 	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CompositeResourceDefinition_id(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceDefinition) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CompositeResourceDefinition",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CompositeResourceDefinition_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceDefinition) (ret graphql.Marshaler) {
@@ -6074,6 +6329,41 @@ func (ec *executionContext) _CompositeResourceValidation_openAPIV3Schema(ctx con
 	return ec.marshalOJSONObject2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Composition_id(ctx context.Context, field graphql.CollectedField, obj *model.Composition) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Composition",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Composition_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.Composition) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -6661,6 +6951,41 @@ func (ec *executionContext) _Condition_message(ctx context.Context, field graphq
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Configuration_id(ctx context.Context, field graphql.CollectedField, obj *model.Configuration) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Configuration",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Configuration_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.Configuration) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -7017,6 +7342,41 @@ func (ec *executionContext) _ConfigurationList_count(ctx context.Context, field 
 	res := resTmp.(int)
 	fc.Result = res
 	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ConfigurationRevision_id(ctx context.Context, field graphql.CollectedField, obj *model.ConfigurationRevision) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ConfigurationRevision",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ConfigurationRevision_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.ConfigurationRevision) (ret graphql.Marshaler) {
@@ -8029,6 +8389,41 @@ func (ec *executionContext) _ConfigurationStatus_currentIdentifier(ctx context.C
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _CustomResourceDefinition_id(ctx context.Context, field graphql.CollectedField, obj *model.CustomResourceDefinition) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CustomResourceDefinition",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _CustomResourceDefinition_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.CustomResourceDefinition) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -8786,6 +9181,41 @@ func (ec *executionContext) _CustomResourceValidation_openAPIV3Schema(ctx contex
 	return ec.marshalOJSONObject2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Event_id(ctx context.Context, field graphql.CollectedField, obj *model.Event) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Event",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Event_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.Event) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -9284,6 +9714,41 @@ func (ec *executionContext) _EventSource_component(ctx context.Context, field gr
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _GenericResource_id(ctx context.Context, field graphql.CollectedField, obj *model.GenericResource) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GenericResource",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _GenericResource_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.GenericResource) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -9563,6 +10028,41 @@ func (ec *executionContext) _LabelSelector_matchLabels(ctx context.Context, fiel
 	res := resTmp.(map[string]interface{})
 	fc.Result = res
 	return ec.marshalOMap2map(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ManagedResource_id(ctx context.Context, field graphql.CollectedField, obj *model.ManagedResource) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ManagedResource",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ManagedResource_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.ManagedResource) (ret graphql.Marshaler) {
@@ -10076,7 +10576,7 @@ func (ec *executionContext) _ObjectMeta_uid(ctx context.Context, field graphql.C
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ObjectMeta_resourceVersion(ctx context.Context, field graphql.CollectedField, obj *model.ObjectMeta) (ret graphql.Marshaler) {
@@ -10619,6 +11119,41 @@ func (ec *executionContext) _PolicyRule_nonResourceURLs(ctx context.Context, fie
 	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Provider_id(ctx context.Context, field graphql.CollectedField, obj *model.Provider) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Provider",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Provider_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.Provider) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -10908,6 +11443,41 @@ func (ec *executionContext) _Provider_revisions(ctx context.Context, field graph
 	res := resTmp.(*model.ProviderRevisionConnection)
 	fc.Result = res
 	return ec.marshalNProviderRevisionConnection2ᚖgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐProviderRevisionConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ProviderConfig_id(ctx context.Context, field graphql.CollectedField, obj *model.ProviderConfig) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ProviderConfig",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ProviderConfig_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.ProviderConfig) (ret graphql.Marshaler) {
@@ -11253,6 +11823,41 @@ func (ec *executionContext) _ProviderList_count(ctx context.Context, field graph
 	res := resTmp.(int)
 	fc.Result = res
 	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ProviderRevision_id(ctx context.Context, field graphql.CollectedField, obj *model.ProviderRevision) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ProviderRevision",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ProviderRevision_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.ProviderRevision) (ret graphql.Marshaler) {
@@ -12502,6 +13107,41 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	res := resTmp.(*introspection.Schema)
 	fc.Result = res
 	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Secret_id(ctx context.Context, field graphql.CollectedField, obj *model.Secret) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Secret",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ReferenceID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Secret_apiVersion(ctx context.Context, field graphql.CollectedField, obj *model.Secret) (ret graphql.Marshaler) {
@@ -14155,6 +14795,113 @@ func (ec *executionContext) _KubernetesResource(ctx context.Context, sel ast.Sel
 	}
 }
 
+func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj model.Node) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case model.CompositeResourceDefinition:
+		return ec._CompositeResourceDefinition(ctx, sel, &obj)
+	case *model.CompositeResourceDefinition:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._CompositeResourceDefinition(ctx, sel, obj)
+	case model.Composition:
+		return ec._Composition(ctx, sel, &obj)
+	case *model.Composition:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Composition(ctx, sel, obj)
+	case model.GenericResource:
+		return ec._GenericResource(ctx, sel, &obj)
+	case *model.GenericResource:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._GenericResource(ctx, sel, obj)
+	case model.Event:
+		return ec._Event(ctx, sel, &obj)
+	case *model.Event:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Event(ctx, sel, obj)
+	case model.Secret:
+		return ec._Secret(ctx, sel, &obj)
+	case *model.Secret:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Secret(ctx, sel, obj)
+	case model.CustomResourceDefinition:
+		return ec._CustomResourceDefinition(ctx, sel, &obj)
+	case *model.CustomResourceDefinition:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._CustomResourceDefinition(ctx, sel, obj)
+	case model.CompositeResource:
+		return ec._CompositeResource(ctx, sel, &obj)
+	case *model.CompositeResource:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._CompositeResource(ctx, sel, obj)
+	case model.CompositeResourceClaim:
+		return ec._CompositeResourceClaim(ctx, sel, &obj)
+	case *model.CompositeResourceClaim:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._CompositeResourceClaim(ctx, sel, obj)
+	case model.Configuration:
+		return ec._Configuration(ctx, sel, &obj)
+	case *model.Configuration:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Configuration(ctx, sel, obj)
+	case model.ConfigurationRevision:
+		return ec._ConfigurationRevision(ctx, sel, &obj)
+	case *model.ConfigurationRevision:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ConfigurationRevision(ctx, sel, obj)
+	case model.ManagedResource:
+		return ec._ManagedResource(ctx, sel, &obj)
+	case *model.ManagedResource:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ManagedResource(ctx, sel, obj)
+	case model.Provider:
+		return ec._Provider(ctx, sel, &obj)
+	case *model.Provider:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Provider(ctx, sel, obj)
+	case model.ProviderRevision:
+		return ec._ProviderRevision(ctx, sel, &obj)
+	case *model.ProviderRevision:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ProviderRevision(ctx, sel, obj)
+	case model.ProviderConfig:
+		return ec._ProviderConfig(ctx, sel, &obj)
+	case *model.ProviderConfig:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ProviderConfig(ctx, sel, obj)
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
@@ -14188,7 +14935,7 @@ func (ec *executionContext) _ComposedResourceConnection(ctx context.Context, sel
 	return out
 }
 
-var compositeResourceImplementors = []string{"CompositeResource", "KubernetesResource", "ComposedResource"}
+var compositeResourceImplementors = []string{"CompositeResource", "Node", "KubernetesResource", "ComposedResource"}
 
 func (ec *executionContext) _CompositeResource(ctx context.Context, sel ast.SelectionSet, obj *model.CompositeResource) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, compositeResourceImplementors)
@@ -14199,6 +14946,11 @@ func (ec *executionContext) _CompositeResource(ctx context.Context, sel ast.Sele
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CompositeResource")
+		case "id":
+			out.Values[i] = ec._CompositeResource_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._CompositeResource_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -14254,7 +15006,7 @@ func (ec *executionContext) _CompositeResource(ctx context.Context, sel ast.Sele
 	return out
 }
 
-var compositeResourceClaimImplementors = []string{"CompositeResourceClaim", "KubernetesResource"}
+var compositeResourceClaimImplementors = []string{"CompositeResourceClaim", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _CompositeResourceClaim(ctx context.Context, sel ast.SelectionSet, obj *model.CompositeResourceClaim) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, compositeResourceClaimImplementors)
@@ -14265,6 +15017,11 @@ func (ec *executionContext) _CompositeResourceClaim(ctx context.Context, sel ast
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CompositeResourceClaim")
+		case "id":
+			out.Values[i] = ec._CompositeResourceClaim_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._CompositeResourceClaim_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -14509,7 +15266,7 @@ func (ec *executionContext) _CompositeResourceConnectionDetails(ctx context.Cont
 	return out
 }
 
-var compositeResourceDefinitionImplementors = []string{"CompositeResourceDefinition", "KubernetesResource"}
+var compositeResourceDefinitionImplementors = []string{"CompositeResourceDefinition", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _CompositeResourceDefinition(ctx context.Context, sel ast.SelectionSet, obj *model.CompositeResourceDefinition) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, compositeResourceDefinitionImplementors)
@@ -14520,6 +15277,11 @@ func (ec *executionContext) _CompositeResourceDefinition(ctx context.Context, se
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CompositeResourceDefinition")
+		case "id":
+			out.Values[i] = ec._CompositeResourceDefinition_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._CompositeResourceDefinition_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -14938,7 +15700,7 @@ func (ec *executionContext) _CompositeResourceValidation(ctx context.Context, se
 	return out
 }
 
-var compositionImplementors = []string{"Composition", "KubernetesResource"}
+var compositionImplementors = []string{"Composition", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _Composition(ctx context.Context, sel ast.SelectionSet, obj *model.Composition) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, compositionImplementors)
@@ -14949,6 +15711,11 @@ func (ec *executionContext) _Composition(ctx context.Context, sel ast.SelectionS
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Composition")
+		case "id":
+			out.Values[i] = ec._Composition_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._Composition_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15127,7 +15894,7 @@ func (ec *executionContext) _Condition(ctx context.Context, sel ast.SelectionSet
 	return out
 }
 
-var configurationImplementors = []string{"Configuration", "KubernetesResource"}
+var configurationImplementors = []string{"Configuration", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _Configuration(ctx context.Context, sel ast.SelectionSet, obj *model.Configuration) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, configurationImplementors)
@@ -15138,6 +15905,11 @@ func (ec *executionContext) _Configuration(ctx context.Context, sel ast.Selectio
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Configuration")
+		case "id":
+			out.Values[i] = ec._Configuration_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._Configuration_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15233,7 +16005,7 @@ func (ec *executionContext) _ConfigurationList(ctx context.Context, sel ast.Sele
 	return out
 }
 
-var configurationRevisionImplementors = []string{"ConfigurationRevision", "KubernetesResource"}
+var configurationRevisionImplementors = []string{"ConfigurationRevision", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _ConfigurationRevision(ctx context.Context, sel ast.SelectionSet, obj *model.ConfigurationRevision) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, configurationRevisionImplementors)
@@ -15244,6 +16016,11 @@ func (ec *executionContext) _ConfigurationRevision(ctx context.Context, sel ast.
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ConfigurationRevision")
+		case "id":
+			out.Values[i] = ec._ConfigurationRevision_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._ConfigurationRevision_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15479,7 +16256,7 @@ func (ec *executionContext) _ConfigurationStatus(ctx context.Context, sel ast.Se
 	return out
 }
 
-var customResourceDefinitionImplementors = []string{"CustomResourceDefinition", "KubernetesResource"}
+var customResourceDefinitionImplementors = []string{"CustomResourceDefinition", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _CustomResourceDefinition(ctx context.Context, sel ast.SelectionSet, obj *model.CustomResourceDefinition) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, customResourceDefinitionImplementors)
@@ -15490,6 +16267,11 @@ func (ec *executionContext) _CustomResourceDefinition(ctx context.Context, sel a
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("CustomResourceDefinition")
+		case "id":
+			out.Values[i] = ec._CustomResourceDefinition_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._CustomResourceDefinition_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15703,7 +16485,7 @@ func (ec *executionContext) _CustomResourceValidation(ctx context.Context, sel a
 	return out
 }
 
-var eventImplementors = []string{"Event"}
+var eventImplementors = []string{"Event", "Node"}
 
 func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, obj *model.Event) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, eventImplementors)
@@ -15714,6 +16496,11 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Event")
+		case "id":
+			out.Values[i] = ec._Event_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._Event_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15826,7 +16613,7 @@ func (ec *executionContext) _EventSource(ctx context.Context, sel ast.SelectionS
 	return out
 }
 
-var genericResourceImplementors = []string{"GenericResource", "KubernetesResource"}
+var genericResourceImplementors = []string{"GenericResource", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _GenericResource(ctx context.Context, sel ast.SelectionSet, obj *model.GenericResource) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, genericResourceImplementors)
@@ -15837,6 +16624,11 @@ func (ec *executionContext) _GenericResource(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("GenericResource")
+		case "id":
+			out.Values[i] = ec._GenericResource_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._GenericResource_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -15935,7 +16727,7 @@ func (ec *executionContext) _LabelSelector(ctx context.Context, sel ast.Selectio
 	return out
 }
 
-var managedResourceImplementors = []string{"ManagedResource", "ComposedResource", "KubernetesResource"}
+var managedResourceImplementors = []string{"ManagedResource", "ComposedResource", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _ManagedResource(ctx context.Context, sel ast.SelectionSet, obj *model.ManagedResource) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, managedResourceImplementors)
@@ -15946,6 +16738,11 @@ func (ec *executionContext) _ManagedResource(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ManagedResource")
+		case "id":
+			out.Values[i] = ec._ManagedResource_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._ManagedResource_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16235,7 +17032,7 @@ func (ec *executionContext) _PolicyRule(ctx context.Context, sel ast.SelectionSe
 	return out
 }
 
-var providerImplementors = []string{"Provider", "KubernetesResource"}
+var providerImplementors = []string{"Provider", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _Provider(ctx context.Context, sel ast.SelectionSet, obj *model.Provider) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, providerImplementors)
@@ -16246,6 +17043,11 @@ func (ec *executionContext) _Provider(ctx context.Context, sel ast.SelectionSet,
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Provider")
+		case "id":
+			out.Values[i] = ec._Provider_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._Provider_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16312,7 +17114,7 @@ func (ec *executionContext) _Provider(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
-var providerConfigImplementors = []string{"ProviderConfig", "KubernetesResource"}
+var providerConfigImplementors = []string{"ProviderConfig", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _ProviderConfig(ctx context.Context, sel ast.SelectionSet, obj *model.ProviderConfig) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, providerConfigImplementors)
@@ -16323,6 +17125,11 @@ func (ec *executionContext) _ProviderConfig(ctx context.Context, sel ast.Selecti
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ProviderConfig")
+		case "id":
+			out.Values[i] = ec._ProviderConfig_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._ProviderConfig_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16425,7 +17232,7 @@ func (ec *executionContext) _ProviderList(ctx context.Context, sel ast.Selection
 	return out
 }
 
-var providerRevisionImplementors = []string{"ProviderRevision", "KubernetesResource"}
+var providerRevisionImplementors = []string{"ProviderRevision", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _ProviderRevision(ctx context.Context, sel ast.SelectionSet, obj *model.ProviderRevision) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, providerRevisionImplementors)
@@ -16436,6 +17243,11 @@ func (ec *executionContext) _ProviderRevision(ctx context.Context, sel ast.Selec
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ProviderRevision")
+		case "id":
+			out.Values[i] = ec._ProviderRevision_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._ProviderRevision_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -16757,7 +17569,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 	return out
 }
 
-var secretImplementors = []string{"Secret", "KubernetesResource"}
+var secretImplementors = []string{"Secret", "Node", "KubernetesResource"}
 
 func (ec *executionContext) _Secret(ctx context.Context, sel ast.SelectionSet, obj *model.Secret) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, secretImplementors)
@@ -16768,6 +17580,11 @@ func (ec *executionContext) _Secret(ctx context.Context, sel ast.SelectionSet, o
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Secret")
+		case "id":
+			out.Values[i] = ec._Secret_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "apiVersion":
 			out.Values[i] = ec._Secret_apiVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -17404,19 +18221,14 @@ func (ec *executionContext) marshalNEventConnection2ᚖgithubᚗcomᚋupboundᚋ
 	return ec._EventConnection(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface{}) (string, error) {
-	res, err := graphql.UnmarshalID(v)
+func (ec *executionContext) unmarshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx context.Context, v interface{}) (model.ReferenceID, error) {
+	var res model.ReferenceID
+	err := res.UnmarshalGQL(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
-	res := graphql.MarshalID(v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-	}
-	return res
+func (ec *executionContext) marshalNID2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐReferenceID(ctx context.Context, sel ast.SelectionSet, v model.ReferenceID) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}) (int, error) {

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -1,6 +1,11 @@
 package model
 
 import (
+	"encoding/base64"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -8,10 +13,89 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/json"
 
-	"github.com/pkg/errors"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
+
+// Reference ID separator.
+const sep = "|"
+
+// Reference ID encoder.
+var encoder = base64.RawStdEncoding
+
+// Reference ID parsing errors.
+var (
+	errDecode    = "cannot decode id"
+	errMalformed = "malformed id"
+	errParse     = "cannot parse id"
+	errType      = "id must be a string"
+)
+
+// A ReferenceID uniquely represents a Kubernetes resource in GraphQL. It
+// encodes to a String per the documentation of its String method, but is
+// otherwise similar to the 'Reference' types (e.g. corev1.ObjectReference) that
+// are used to identify Kubernetes objects.
+type ReferenceID struct {
+	APIVersion string
+	Kind       string
+	Namespace  string
+	Name       string
+}
+
+// ParseReferenceID parses the supplied ID string.
+func ParseReferenceID(id string) (ReferenceID, error) {
+	b, err := encoder.DecodeString(id)
+	if err != nil {
+		return ReferenceID{}, errors.Wrap(err, errDecode)
+	}
+
+	parts := strings.Split(string(b), sep)
+	if len(parts) != 4 {
+		return ReferenceID{}, errors.New(errMalformed)
+	}
+
+	out := ReferenceID{
+		APIVersion: parts[0],
+		Kind:       parts[1],
+		Namespace:  parts[2],
+		Name:       parts[3],
+	}
+
+	return out, nil
+}
+
+// A String representation of a ReferenceID. The idea is to store the data that
+// uniquely identifies a resource in the Kubernetes API (a reference) such that
+// we can extract that data from a given ID string in future. Representing this
+// data as a string gives GraphQL clients a single, idiomatic scalar field they
+// may consider the "primary key" of a resource.
+//
+// We serialise the reference as "apiVersion|kind|namespace|name", then base64
+// encode it in a mild attempt to reinforce the fact that clients must treat it
+// as opaque. Cluster scoped resources have an empty namespace 'field', i.e.
+// "apiVersion|kind||name"
+func (id *ReferenceID) String() string {
+	return encoder.EncodeToString([]byte(id.APIVersion + sep + id.Kind + sep + id.Namespace + sep + id.Name))
+}
+
+// UnmarshalGQL unmarshals a ReferenceID.
+func (id *ReferenceID) UnmarshalGQL(v interface{}) error {
+	s, ok := v.(string)
+	if !ok {
+		return errors.New(errType)
+	}
+	in, err := ParseReferenceID(s)
+	if err != nil {
+		return errors.Wrap(err, errParse)
+	}
+
+	*id = in
+	return nil
+}
+
+// MarshalGQL marshals a ReferenceID as a string.
+func (id ReferenceID) MarshalGQL(w io.Writer) {
+	_, _ = w.Write([]byte(`"` + id.String() + `"`))
+}
 
 // GetConditions from the supplied Crossplane conditions.
 func GetConditions(in []xpv1.Condition) []Condition {
@@ -101,6 +185,12 @@ func GetGenericResource(u *kunstructured.Unstructured) (GenericResource, error) 
 	}
 
 	out := GenericResource{
+		ID: ReferenceID{
+			APIVersion: u.GetAPIVersion(),
+			Kind:       u.GetKind(),
+			Namespace:  u.GetNamespace(),
+			Name:       u.GetName(),
+		},
 		APIVersion: u.GetAPIVersion(),
 		Kind:       u.GetKind(),
 		Metadata:   GetObjectMeta(u),
@@ -118,6 +208,13 @@ func GetSecret(s *corev1.Secret) (Secret, error) {
 	}
 
 	out := Secret{
+		ID: ReferenceID{
+			APIVersion: s.APIVersion,
+			Kind:       s.Kind,
+			Namespace:  s.GetNamespace(),
+			Name:       s.GetName(),
+		},
+
 		APIVersion: s.APIVersion,
 		Kind:       s.Kind,
 		Metadata:   GetObjectMeta(s),
@@ -135,6 +232,12 @@ func GetCustomResourceDefinition(crd *extv1.CustomResourceDefinition) (CustomRes
 	}
 
 	out := CustomResourceDefinition{
+		ID: ReferenceID{
+			APIVersion: crd.APIVersion,
+			Kind:       crd.Kind,
+			Name:       crd.GetName(),
+		},
+
 		APIVersion: crd.APIVersion,
 		Kind:       crd.Kind,
 		Metadata:   GetObjectMeta(crd),

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -1,0 +1,113 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestReferenceID(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		id     ReferenceID
+		want   string
+	}{
+		"Namespaced": {
+			reason: "It should be possible to encode a namespaced ID",
+			id: ReferenceID{
+				APIVersion: "example.org/v1",
+				Kind:       "ExampleKind",
+				Namespace:  "default",
+				Name:       "example",
+			},
+			want: "ZXhhbXBsZS5vcmcvdjF8RXhhbXBsZUtpbmR8ZGVmYXVsdHxleGFtcGxl",
+		},
+		"ClusterScoped": {
+			reason: "It should be possible to encode a cluster scoped ID",
+			id: ReferenceID{
+				APIVersion: "example.org/v1",
+				Kind:       "ExampleKind",
+				Name:       "example",
+			},
+			want: "ZXhhbXBsZS5vcmcvdjF8RXhhbXBsZUtpbmR8fGV4YW1wbGU",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.id.String()
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nid.String(): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestParseReferenceID(t *testing.T) {
+	_, decodeErr := encoder.DecodeString("=")
+
+	type want struct {
+		id  ReferenceID
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		id     string
+		want   want
+	}{
+		"Namespaced": {
+			reason: "It should be possible to decode a namespaced ID",
+			id:     "ZXhhbXBsZS5vcmcvdjF8RXhhbXBsZUtpbmR8ZGVmYXVsdHxleGFtcGxl",
+			want: want{
+				id: ReferenceID{
+					APIVersion: "example.org/v1",
+					Kind:       "ExampleKind",
+					Namespace:  "default",
+					Name:       "example",
+				},
+			},
+		},
+		"ClusterScoped": {
+			reason: "It should be possible to decode a cluster scoped ID",
+			id:     "ZXhhbXBsZS5vcmcvdjF8RXhhbXBsZUtpbmR8fGV4YW1wbGU",
+			want: want{
+				id: ReferenceID{
+					APIVersion: "example.org/v1",
+					Kind:       "ExampleKind",
+					Name:       "example",
+				},
+			},
+		},
+		"WrongEncoding": {
+			reason: "Attempting to parse an ID that is not base64 encoded should result in an error",
+			id:     "=",
+			want: want{
+				err: errors.Wrap(decodeErr, errDecode),
+			},
+		},
+		"WrongParts": {
+			reason: "Attempting to parse a malformed ID should result in an error",
+			id:     "cG90YXRvCg",
+			want: want{
+				err: errors.New(errMalformed),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseReferenceID(tc.id)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nParseReferenceID(%q): -want error, +got error:\n%s", tc.reason, tc.id, diff)
+			}
+			if diff := cmp.Diff(tc.want.id, got, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nParseReferenceID(%q): -want, +got:\n%s", tc.reason, tc.id, diff)
+			}
+		})
+	}
+}

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -42,6 +42,12 @@ func GetCompositeResource(u *kunstructured.Unstructured) (CompositeResource, err
 	}
 
 	out := CompositeResource{
+		ID: ReferenceID{
+			APIVersion: xr.GetAPIVersion(),
+			Kind:       xr.GetKind(),
+			Name:       xr.GetName(),
+		},
+
 		APIVersion: xr.GetAPIVersion(),
 		Kind:       xr.GetKind(),
 		Metadata:   GetObjectMeta(xr),

--- a/internal/graph/model/generated.go
+++ b/internal/graph/model/generated.go
@@ -21,12 +21,17 @@ type KubernetesResource interface {
 	IsKubernetesResource()
 }
 
+type Node interface {
+	IsNode()
+}
+
 type ComposedResourceConnection struct {
 	Items []ComposedResource `json:"items"`
 	Count int                `json:"count"`
 }
 
 type CompositeResource struct {
+	ID         ReferenceID              `json:"id"`
 	APIVersion string                   `json:"apiVersion"`
 	Kind       string                   `json:"kind"`
 	Metadata   *ObjectMeta              `json:"metadata"`
@@ -36,10 +41,12 @@ type CompositeResource struct {
 	Events     *EventConnection         `json:"events"`
 }
 
+func (CompositeResource) IsNode()               {}
 func (CompositeResource) IsKubernetesResource() {}
 func (CompositeResource) IsComposedResource()   {}
 
 type CompositeResourceClaim struct {
+	ID         ReferenceID                   `json:"id"`
 	APIVersion string                        `json:"apiVersion"`
 	Kind       string                        `json:"kind"`
 	Metadata   *ObjectMeta                   `json:"metadata"`
@@ -49,6 +56,7 @@ type CompositeResourceClaim struct {
 	Events     *EventConnection              `json:"events"`
 }
 
+func (CompositeResourceClaim) IsNode()               {}
 func (CompositeResourceClaim) IsKubernetesResource() {}
 
 type CompositeResourceClaimConnection struct {
@@ -84,6 +92,7 @@ type CompositeResourceConnectionDetails struct {
 }
 
 type CompositeResourceDefinition struct {
+	ID                             ReferenceID                        `json:"id"`
 	APIVersion                     string                             `json:"apiVersion"`
 	Kind                           string                             `json:"kind"`
 	Metadata                       *ObjectMeta                        `json:"metadata"`
@@ -95,6 +104,7 @@ type CompositeResourceDefinition struct {
 	DefinedCompositeResourceClaims *CompositeResourceClaimConnection  `json:"definedCompositeResourceClaims"`
 }
 
+func (CompositeResourceDefinition) IsNode()               {}
 func (CompositeResourceDefinition) IsKubernetesResource() {}
 
 type CompositeResourceDefinitionControllerStatus struct {
@@ -142,6 +152,7 @@ type CompositeResourceValidation struct {
 }
 
 type Composition struct {
+	ID         ReferenceID        `json:"id"`
 	APIVersion string             `json:"apiVersion"`
 	Kind       string             `json:"kind"`
 	Metadata   *ObjectMeta        `json:"metadata"`
@@ -151,6 +162,7 @@ type Composition struct {
 	Events     *EventConnection   `json:"events"`
 }
 
+func (Composition) IsNode()               {}
 func (Composition) IsKubernetesResource() {}
 
 type CompositionList struct {
@@ -178,6 +190,7 @@ type Condition struct {
 }
 
 type Configuration struct {
+	ID         ReferenceID                      `json:"id"`
 	APIVersion string                           `json:"apiVersion"`
 	Kind       string                           `json:"kind"`
 	Metadata   *ObjectMeta                      `json:"metadata"`
@@ -188,6 +201,7 @@ type Configuration struct {
 	Revisions  *ConfigurationRevisionConnection `json:"revisions"`
 }
 
+func (Configuration) IsNode()               {}
 func (Configuration) IsKubernetesResource() {}
 
 type ConfigurationList struct {
@@ -196,6 +210,7 @@ type ConfigurationList struct {
 }
 
 type ConfigurationRevision struct {
+	ID         ReferenceID                  `json:"id"`
 	APIVersion string                       `json:"apiVersion"`
 	Kind       string                       `json:"kind"`
 	Metadata   *ObjectMeta                  `json:"metadata"`
@@ -205,6 +220,7 @@ type ConfigurationRevision struct {
 	Events     *EventConnection             `json:"events"`
 }
 
+func (ConfigurationRevision) IsNode()               {}
 func (ConfigurationRevision) IsKubernetesResource() {}
 
 type ConfigurationRevisionConnection struct {
@@ -239,6 +255,7 @@ type ConfigurationStatus struct {
 func (ConfigurationStatus) IsConditionedStatus() {}
 
 type CustomResourceDefinition struct {
+	ID               ReferenceID                     `json:"id"`
 	APIVersion       string                          `json:"apiVersion"`
 	Kind             string                          `json:"kind"`
 	Metadata         *ObjectMeta                     `json:"metadata"`
@@ -249,6 +266,7 @@ type CustomResourceDefinition struct {
 	DefinedResources *KubernetesResourceConnection   `json:"definedResources"`
 }
 
+func (CustomResourceDefinition) IsNode()               {}
 func (CustomResourceDefinition) IsKubernetesResource() {}
 
 type CustomResourceDefinitionNames struct {
@@ -283,6 +301,7 @@ type CustomResourceValidation struct {
 }
 
 type Event struct {
+	ID             ReferenceID        `json:"id"`
 	APIVersion     string             `json:"apiVersion"`
 	Kind           string             `json:"kind"`
 	Metadata       *ObjectMeta        `json:"metadata"`
@@ -297,6 +316,8 @@ type Event struct {
 	Raw            string             `json:"raw"`
 }
 
+func (Event) IsNode() {}
+
 type EventConnection struct {
 	Items []Event `json:"items"`
 	Count int     `json:"count"`
@@ -307,6 +328,7 @@ type EventSource struct {
 }
 
 type GenericResource struct {
+	ID         ReferenceID      `json:"id"`
 	APIVersion string           `json:"apiVersion"`
 	Kind       string           `json:"kind"`
 	Metadata   *ObjectMeta      `json:"metadata"`
@@ -314,6 +336,7 @@ type GenericResource struct {
 	Events     *EventConnection `json:"events"`
 }
 
+func (GenericResource) IsNode()               {}
 func (GenericResource) IsKubernetesResource() {}
 
 type KubernetesResourceConnection struct {
@@ -326,6 +349,7 @@ type LabelSelector struct {
 }
 
 type ManagedResource struct {
+	ID         ReferenceID            `json:"id"`
 	APIVersion string                 `json:"apiVersion"`
 	Kind       string                 `json:"kind"`
 	Metadata   *ObjectMeta            `json:"metadata"`
@@ -336,6 +360,7 @@ type ManagedResource struct {
 }
 
 func (ManagedResource) IsComposedResource()   {}
+func (ManagedResource) IsNode()               {}
 func (ManagedResource) IsKubernetesResource() {}
 
 type ManagedResourceStatus struct {
@@ -363,6 +388,7 @@ type PolicyRule struct {
 }
 
 type Provider struct {
+	ID         ReferenceID                 `json:"id"`
 	APIVersion string                      `json:"apiVersion"`
 	Kind       string                      `json:"kind"`
 	Metadata   *ObjectMeta                 `json:"metadata"`
@@ -373,9 +399,11 @@ type Provider struct {
 	Revisions  *ProviderRevisionConnection `json:"revisions"`
 }
 
+func (Provider) IsNode()               {}
 func (Provider) IsKubernetesResource() {}
 
 type ProviderConfig struct {
+	ID         ReferenceID           `json:"id"`
 	APIVersion string                `json:"apiVersion"`
 	Kind       string                `json:"kind"`
 	Metadata   *ObjectMeta           `json:"metadata"`
@@ -384,6 +412,7 @@ type ProviderConfig struct {
 	Raw        string                `json:"raw"`
 }
 
+func (ProviderConfig) IsNode()               {}
 func (ProviderConfig) IsKubernetesResource() {}
 
 type ProviderConfigStatus struct {
@@ -399,6 +428,7 @@ type ProviderList struct {
 }
 
 type ProviderRevision struct {
+	ID         ReferenceID             `json:"id"`
 	APIVersion string                  `json:"apiVersion"`
 	Kind       string                  `json:"kind"`
 	Metadata   *ObjectMeta             `json:"metadata"`
@@ -408,6 +438,7 @@ type ProviderRevision struct {
 	Events     *EventConnection        `json:"events"`
 }
 
+func (ProviderRevision) IsNode()               {}
 func (ProviderRevision) IsKubernetesResource() {}
 
 type ProviderRevisionConnection struct {
@@ -442,6 +473,7 @@ type ProviderStatus struct {
 func (ProviderStatus) IsConditionedStatus() {}
 
 type Secret struct {
+	ID         ReferenceID      `json:"id"`
 	APIVersion string           `json:"apiVersion"`
 	Kind       string           `json:"kind"`
 	Metadata   *ObjectMeta      `json:"metadata"`
@@ -450,6 +482,7 @@ type Secret struct {
 	Events     *EventConnection `json:"events"`
 }
 
+func (Secret) IsNode()               {}
 func (Secret) IsKubernetesResource() {}
 
 type SecretConnection struct {

--- a/internal/graph/model/managed.go
+++ b/internal/graph/model/managed.go
@@ -33,6 +33,12 @@ func GetManagedResource(u *kunstructured.Unstructured) (ManagedResource, error) 
 	}
 
 	out := ManagedResource{
+		ID: ReferenceID{
+			APIVersion: mg.GetAPIVersion(),
+			Kind:       mg.GetKind(),
+			Name:       mg.GetName(),
+		},
+
 		APIVersion: mg.GetAPIVersion(),
 		Kind:       mg.GetKind(),
 		Metadata:   GetObjectMeta(mg),

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -82,6 +82,12 @@ func GetProvider(p *pkgv1.Provider) (Provider, error) {
 	}
 
 	out := Provider{
+		ID: ReferenceID{
+			APIVersion: p.APIVersion,
+			Kind:       p.Kind,
+			Name:       p.GetName(),
+		},
+
 		APIVersion: p.APIVersion,
 		Kind:       p.Kind,
 		Metadata:   GetObjectMeta(p),
@@ -112,6 +118,12 @@ func GetProviderRevision(pr *pkgv1.ProviderRevision) (ProviderRevision, error) {
 	}
 
 	out := ProviderRevision{
+		ID: ReferenceID{
+			APIVersion: pr.APIVersion,
+			Kind:       pr.Kind,
+			Name:       pr.GetName(),
+		},
+
 		APIVersion: pr.APIVersion,
 		Kind:       pr.Kind,
 		Metadata:   GetObjectMeta(pr),
@@ -145,6 +157,12 @@ func GetConfiguration(c *pkgv1.Configuration) (Configuration, error) {
 	}
 
 	out := Configuration{
+		ID: ReferenceID{
+			APIVersion: c.APIVersion,
+			Kind:       c.Kind,
+			Name:       c.GetName(),
+		},
+
 		APIVersion: c.APIVersion,
 		Kind:       c.Kind,
 		Metadata:   GetObjectMeta(c),
@@ -175,6 +193,12 @@ func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision) (ConfigurationRev
 	}
 
 	out := ConfigurationRevision{
+		ID: ReferenceID{
+			APIVersion: cr.APIVersion,
+			Kind:       cr.Kind,
+			Name:       cr.GetName(),
+		},
+
 		APIVersion: cr.APIVersion,
 		Kind:       cr.Kind,
 		Metadata:   GetObjectMeta(cr),

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -19,6 +19,12 @@ func GetProviderConfig(u *kunstructured.Unstructured) (ProviderConfig, error) {
 	}
 
 	out := ProviderConfig{
+		ID: ReferenceID{
+			APIVersion: pc.GetAPIVersion(),
+			Kind:       pc.GetKind(),
+			Name:       pc.GetName(),
+		},
+
 		APIVersion: pc.GetAPIVersion(),
 		Kind:       pc.GetKind(),
 		Metadata:   GetObjectMeta(pc),

--- a/schema/apiextensions.gql
+++ b/schema/apiextensions.gql
@@ -1,4 +1,6 @@
-type CompositeResourceDefinition implements KubernetesResource {
+type CompositeResourceDefinition implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -67,7 +69,9 @@ type TypeReference {
   kind: String!
 }
 
-type Composition implements KubernetesResource {
+type Composition implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!

--- a/schema/common.gql
+++ b/schema/common.gql
@@ -2,7 +2,13 @@ scalar Time
 scalar Map
 scalar JSONObject
 
+interface Node {
+  id: ID!
+}
+
 interface KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -21,7 +27,9 @@ type KubernetesResourceConnection {
   count: Int!
 }
 
-type GenericResource implements KubernetesResource {
+type GenericResource implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -36,7 +44,7 @@ type ObjectMeta {
   name: String!
   generateName: String
   namespace: String
-  uid: ID!
+  uid: String!
   resourceVersion: String!
   generation: Int!
   creationTime: Time!
@@ -89,7 +97,13 @@ type LabelSelector {
   matchLabels: Map
 }
 
-type Event {
+# NOTE(negz): Event does not implement KubernetesResource simply because an
+# event does not have events. We might consider creating a distinct
+# InvolvedObject interface (or something like that) for the events field.
+
+type Event implements Node {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -114,7 +128,9 @@ enum EventType {
   Warning
 }
 
-type Secret implements KubernetesResource {
+type Secret implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -130,7 +146,9 @@ type SecretConnection {
   count: Int!
 }
 
-type CustomResourceDefinition implements KubernetesResource {
+type CustomResourceDefinition implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!

--- a/schema/composite.gql
+++ b/schema/composite.gql
@@ -1,4 +1,6 @@
-type CompositeResource implements KubernetesResource {
+type CompositeResource implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -38,7 +40,9 @@ type CompositeResourceConnectionDetails {
   lastPublishedTime: Time
 }
 
-type CompositeResourceClaim implements KubernetesResource {
+type CompositeResourceClaim implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!

--- a/schema/configuration.gql
+++ b/schema/configuration.gql
@@ -1,4 +1,6 @@
-type Configuration implements KubernetesResource {
+type Configuration implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -38,7 +40,9 @@ type ConfigurationStatus implements ConditionedStatus {
   currentIdentifier: String
 }
 
-type ConfigurationRevision implements KubernetesResource {
+type ConfigurationRevision implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!

--- a/schema/managed.gql
+++ b/schema/managed.gql
@@ -1,4 +1,6 @@
-type ManagedResource implements KubernetesResource {
+type ManagedResource implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!

--- a/schema/provider.gql
+++ b/schema/provider.gql
@@ -1,4 +1,6 @@
-type Provider implements KubernetesResource {
+type Provider implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!
@@ -38,7 +40,9 @@ type ProviderStatus implements ConditionedStatus {
   currentIdentifier: String
 }
 
-type ProviderRevision implements KubernetesResource {
+type ProviderRevision implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!

--- a/schema/providerconfig.gql
+++ b/schema/providerconfig.gql
@@ -1,4 +1,6 @@
-type ProviderConfig implements KubernetesResource {
+type ProviderConfig implements Node & KubernetesResource {
+  id: ID!
+
   apiVersion: String!
   kind: String!
   metadata: ObjectMeta!


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #7

The idea is to store the data that uniquely identifies a resource in the Kubernetes API such that we can extract that data from a given ID string in future. Kubernetes resources are uniquely identified by their API version, kind, namespace (where relevant), and name. This set of data is often called 'a reference' or 'an object reference'. While all of this data already exists in our API representing it as a string gives GraphQL clients a single, idiomatic scalar field they may consider the "primary key" of a type.

Each ID is a Kubernetes reference serialised as "apiVersion|kind|namespace|name" and base64 encoded in a mild attempt to reinforce the fact that clients must treat it as opaque. Cluster scoped resources have an empty namespace 'field', i.e. "apiVersion|kind||name".

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

Apart from the unit tests, I've `go run` it and confirmed that IDs show up when I query for installed configurations and providers. In particular, this means that the process of extracting a reference from an ID string has currently only been tested via unit tests.