### PR TITLE
Make the running version of xgql discoverable

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,28 @@
+package version
+
+import "net/http"
+
+// Note that the Version string below is overridden at build time by the xgql
+// Makefile, using ldflags.
+
+// Version of xgql.
+var Version = "unknown"
+
+const (
+	header = "X-Xgql-Version"
+)
+
+// Middleware injects the xgql version into the HTTP response headers.
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add(header, Version)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Handler returns the running xgql version.
+func Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(Version))
+	})
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/xgql/issues/19

This commit adds a version package with an exported Version variable. This
version is set by the Makefile at build time, and exposed:

* Via the --version flag.
* As a simple string at the /version endpoint.
* In the X-Xgql-Version response header of all responses.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've built xgql, run it with `--version`, hit the `/version` endpoint, and used Chrome dev tools to confirm that the `X-Xgql-Version` response header is present in all HTTP responses.