### PR TITLE
Support serving via TLS

### DIFF
--- a/cluster/charts/xgql/templates/deployment.yaml
+++ b/cluster/charts/xgql/templates/deployment.yaml
@@ -53,6 +53,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- if .Values.tlsSecret }}
+        volumeMounts:
+        - mountPath: /tls
+          name: tls
+          readOnly: true
+        {{- end}}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
@@ -62,3 +68,10 @@ spec:
       {{- if .Values.affinity }}
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.tlsSecret }}
+      volumes:
+      - name: tls
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.tlsSecret }}
+      {{- end}}

--- a/cluster/charts/xgql/values.yaml.tmpl
+++ b/cluster/charts/xgql/values.yaml.tmpl
@@ -11,6 +11,10 @@ nodeSelector: {}
 tolerations: {}
 affinity: {}
 
+# Uncomment to serve via TLS.
+# tlsSecret: xgql-certs
+# args: {"--tls-key=/tls/tls.key", "--tls-cert=/tls/tls.crt"}
+
 args: {}
 
 imagePullSecrets:


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/xgql/issues/15

We still support serving via plaintext (e.g. for metrics and development), but this is now restricted to localhost by default.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
I've started xgql with a self-signed certificate, and confirmed the Helm chart renders and installs correctly when run with:

```console
FLAGS="--set tlsSecret=xgql-certs --set args={--debug,--tls-cert=/tls/tls.crt,--tls-key=/tls/tls.key}" ./cluster/local/kind.sh helm-install
```