### PR TITLE
Have resolution timeout after 5 seconds

### DIFF
--- a/internal/graph/present/present.go
+++ b/internal/graph/present/present.go
@@ -1,0 +1,47 @@
+package present
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/pkg/errors"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	errRBAC = "possible RBAC permissions error"
+)
+
+// wrap adds context to a *gqlerror.Error message while maintaining metadata
+// such as its ast.Path that would be obfuscated by errors.Wrap.
+func wrap(err error, message string) error {
+	gerr := &gqlerror.Error{}
+	if !errors.As(err, &gerr) {
+		return errors.Wrap(err, message)
+	}
+
+	gerr.Message = message + ": " + gerr.Message
+	return gerr
+}
+
+// Error 'presents' errors encountered by GraphQL resolvers.
+func Error(ctx context.Context, err error) *gqlerror.Error {
+	// Most xgql resolvers read from a controller-runtime cache that is hydrated
+	// by taking a watch on any type they're asked to read. The cache uses the
+	// credentials passed in by the caller, and will never start if those
+	// credentials can't take a watch on the desired type for some reason. If
+	// the cache hasn't started by the time the resolver's context is cancelled
+	// it will return a timeout error with an obtuse message about an "informer
+	// failing to sync". The most common reason a cache won't start is because
+	// the caller doesn't have RBAC permissions to list or watch the desired
+	// type, so we wrap the error with a hint.
+	if kerrors.IsTimeout(err) {
+		err = wrap(err, errRBAC)
+	}
+
+	// ErrorOnPath will 'upgrade' the supplied error to a GraphQL error if it
+	// wasn't one already.
+	err = graphql.ErrorOnPath(ctx, err)
+	return err.(*gqlerror.Error) //nolint:errorlint // We know err will be a *graphql.Error.
+}

--- a/internal/graph/present/present_test.go
+++ b/internal/graph/present/present_test.go
@@ -1,0 +1,78 @@
+package present
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+func TestError(t *testing.T) {
+	errTimeout := kerrors.NewTimeoutError("too slow", 0)
+	errBoom := errors.New("boom")
+
+	gerrTimeout := gqlerror.WrapPath(nil, errTimeout)
+	gerrBoom := gqlerror.WrapPath(nil, errBoom)
+
+	type args struct {
+		ctx context.Context
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   *gqlerror.Error
+	}{
+		"TimeoutGQLError": {
+			reason: "Timeout errors should be decorated with context a hint about RBAC.",
+			args: args{
+				ctx: context.Background(),
+				err: gerrTimeout,
+			},
+			want: &gqlerror.Error{
+				Message: errRBAC + ": " + gerrTimeout.Message,
+			},
+		},
+		"OtherGQLError": {
+			reason: "Regular GQL errors should be returned unchanged.",
+			args: args{
+				ctx: context.Background(),
+				err: gerrBoom,
+			},
+			want: gerrBoom,
+		},
+		"OtherTimeoutError": {
+			reason: "Non-GQL timeout errors should be both decorated and 'upgraded' to a GQL error.",
+			args: args{
+				ctx: context.Background(),
+				err: errTimeout,
+			},
+			want: &gqlerror.Error{
+				Message: errRBAC + ": " + gerrTimeout.Message,
+			},
+		},
+		"OtherError": {
+			reason: "Non-GQL errors should be 'upgraded' to a GQL error.",
+			args: args{
+				ctx: context.Background(),
+				err: errBoom,
+			},
+			want: gerrBoom,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := Error(tc.args.ctx, tc.args.err)
+			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
+				t.Errorf("%s\nError(...): -want, +got\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -25,8 +25,10 @@ func (r *xrd) Events(ctx context.Context, obj *model.CompositeResourceDefinition
 }
 
 func (r *xrd) DefinedCompositeResources(ctx context.Context, obj *model.CompositeResourceDefinition, version *string) (*model.CompositeResourceConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))

--- a/internal/graph/resolvers/common.go
+++ b/internal/graph/resolvers/common.go
@@ -25,8 +25,10 @@ func (r *crd) Events(ctx context.Context, obj *model.CustomResourceDefinition) (
 }
 
 func (r *crd) DefinedResources(ctx context.Context, obj *model.CustomResourceDefinition, version *string) (*model.KubernetesResourceConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -32,6 +32,9 @@ func (r *configuration) Events(ctx context.Context, obj *model.Configuration) (*
 }
 
 func (r *configuration) Revisions(ctx context.Context, obj *model.Configuration, active *bool) (*model.ConfigurationRevisionConnection, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	t, _ := token.FromContext(ctx)
 
 	c, err := r.clients.Get(t)
@@ -85,8 +88,10 @@ type configurationRevisionStatus struct {
 }
 
 func (r *configurationRevisionStatus) Objects(ctx context.Context, obj *model.ConfigurationRevisionStatus) (*model.KubernetesResourceConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))

--- a/internal/graph/resolvers/managed.go
+++ b/internal/graph/resolvers/managed.go
@@ -25,8 +25,10 @@ func (r *managedResourceSpec) ConnectionSecret(ctx context.Context, obj *model.M
 		return nil, nil
 	}
 
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))

--- a/internal/graph/resolvers/objectmeta.go
+++ b/internal/graph/resolvers/objectmeta.go
@@ -23,8 +23,10 @@ type objectMeta struct {
 }
 
 func (r *objectMeta) Owners(ctx context.Context, obj *model.ObjectMeta, controller *bool) (*model.OwnerConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -31,8 +31,10 @@ func (r *provider) Events(ctx context.Context, obj *model.Provider) (*model.Even
 }
 
 func (r *provider) Revisions(ctx context.Context, obj *model.Provider, active *bool) (*model.ProviderRevisionConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))
@@ -84,8 +86,10 @@ type providerRevisionStatus struct {
 }
 
 func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.ProviderRevisionStatus) (*model.KubernetesResourceConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -23,8 +23,10 @@ type query struct {
 }
 
 func (r *query) Providers(ctx context.Context) (*model.ProviderConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))
@@ -50,8 +52,10 @@ func (r *query) Providers(ctx context.Context) (*model.ProviderConnection, error
 }
 
 func (r *query) Configurations(ctx context.Context) (*model.ConfigurationConnection, error) {
-	t, _ := token.FromContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
+	t, _ := token.FromContext(ctx)
 	c, err := r.clients.Get(t)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))

--- a/internal/graph/resolvers/root.go
+++ b/internal/graph/resolvers/root.go
@@ -1,11 +1,16 @@
 package resolvers
 
 import (
+	"time"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/generated"
 )
+
+// Default resolver timeout.
+const timeout = 5 * time.Second
 
 // A ClientCache can produce a client for a given token.
 type ClientCache interface {


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/xgql/issues/31

This PR adds a 5 second timeout to all resolvers, as well as a general timeout HTTP reads and writes. The resolver timeouts prevent resolution from blocking indefinitely. This behaviour has been seen when we can't start a cache for the caller because they do not have RBAC permissions to list or watch the a type they have queried for.

The commit also adds an error handler that decorates any error that appears to be a cache timeout with a hint that the error may be caused by lacking RBAC permissions.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
I've confirmed that queries for types to which the caller does not have RBAC access timeout after 5 seconds with an error like the following:

```console
possible RBAC permissions error: cannot get custom resource definition: Timeout: failed waiting for *v1.CustomResourceDefinition Informer to sync
```

If the caller has access to some but not all of the underlying types they've queried for we'll return whatever types we can, along with errors for the other. e.g. The above error came from a query in which the caller had RBAC access to providers and provider revisions, but not to CRDs. The query returned the providers and revisions, plus an error for each CRD that could not be returned.