### PR TITLE
Support resolving events

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -56,6 +56,8 @@ var noCache = []client.Object{
 	// they could end up as the owner reference of a resource we're concerned
 	// with, and we don't want to try to watch (e.g.) all pods in the cluster
 	// just because a pod somehow became the owner reference of an XR.
+	&corev1.Node{},
+	&corev1.Namespace{},
 	&corev1.Pod{},
 	&corev1.ConfigMap{},
 	&corev1.Service{},

--- a/internal/graph/model/event.go
+++ b/internal/graph/model/event.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+// An Event pertaining to a Kubernetes resource.
+type Event struct {
+	// An opaque identifier that is unique across all types.
+	ID ReferenceID `json:"id"`
+
+	// The underlying Kubernetes API version of this resource.
+	APIVersion string `json:"apiVersion"`
+
+	// The underlying Kubernetes API kind of this resource.
+	Kind string `json:"kind"`
+
+	// Metadata that is common to all Kubernetes API resources.
+	Metadata *ObjectMeta `json:"metadata"`
+
+	// The type of event.
+	Type *EventType `json:"type"`
+
+	// The reason the event was emitted.
+	Reason *string `json:"reason"`
+
+	// Details about the event, if any.
+	Message *string `json:"message"`
+
+	// The source of the event - e.g. a controller.
+	Source *EventSource `json:"source"`
+
+	// The number of times this event has occurred.
+	Count *int `json:"count"`
+
+	// The time at which this event was first recorded.
+	FirstTime *time.Time `json:"firstTime"`
+
+	// The time at which this event was most recently recorded.
+	LastTime *time.Time `json:"lastTime"`
+
+	// A raw JSON representation of the event.
+	Raw string `json:"raw"`
+
+	InvolvedObjectRef corev1.ObjectReference
+}
+
+// IsNode indicates that an Event satisfies the GraphQL node interface.
+func (Event) IsNode() {}
+
+// GetEventType from the supplied Kubernetes event type.
+func GetEventType(in string) *EventType {
+	switch in {
+	case "Warning":
+		t := EventTypeWarning
+		return &t
+	case "Normal":
+		t := EventTypeNormal
+		return &t
+	default:
+		return nil
+	}
+}
+
+// GetEvent from the supplied Kubernetes event.
+func GetEvent(e *corev1.Event) Event {
+	out := Event{
+		ID: ReferenceID{
+			APIVersion: e.APIVersion,
+			Kind:       e.Kind,
+			Namespace:  e.GetNamespace(),
+			Name:       e.GetName(),
+		},
+		APIVersion:        e.APIVersion,
+		Kind:              e.Kind,
+		Metadata:          GetObjectMeta(e),
+		Type:              GetEventType(e.Type),
+		Raw:               raw(e),
+		InvolvedObjectRef: e.InvolvedObject,
+	}
+
+	if e.Reason != "" {
+		out.Reason = pointer.StringPtr(e.Reason)
+	}
+	if e.Message != "" {
+		out.Message = pointer.StringPtr(e.Message)
+	}
+	if e.Count != 0 {
+		c := int(e.Count)
+		out.Count = &c
+	}
+	if e.Source.Component != "" {
+		out.Source = &EventSource{Component: pointer.StringPtr(e.Source.Component)}
+	}
+	ft := e.FirstTimestamp.Time
+	out.FirstTime = &ft
+	lt := e.LastTimestamp.Time
+	out.LastTime = &lt
+
+	return out
+}

--- a/internal/graph/model/event_test.go
+++ b/internal/graph/model/event_test.go
@@ -1,0 +1,85 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
+)
+
+func TestGetEvent(t *testing.T) {
+	now := time.Now()
+	warn := EventTypeWarning
+
+	cases := map[string]struct {
+		reason string
+		s      *corev1.Event
+		want   Event
+	}{
+		"Full": {
+			reason: "All supported fields should be converted to our model",
+			s: &corev1.Event{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kschema.GroupVersion{Group: corev1.GroupName, Version: "v1"}.String(),
+					Kind:       "Event",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cool",
+				},
+				Type:    "Warning",
+				Reason:  "BadStuff",
+				Message: "Bad stuff happened.",
+				Count:   42,
+				Source: corev1.EventSource{
+					Component: "that-thing",
+				},
+				FirstTimestamp: metav1.Time{Time: now},
+				LastTimestamp:  metav1.Time{Time: now},
+			},
+			want: Event{
+				ID: ReferenceID{
+					APIVersion: kschema.GroupVersion{Group: corev1.GroupName, Version: "v1"}.String(),
+					Kind:       "Event",
+					Name:       "cool",
+				},
+				APIVersion: kschema.GroupVersion{Group: corev1.GroupName, Version: "v1"}.String(),
+				Kind:       "Event",
+				Metadata: &ObjectMeta{
+					Name: "cool",
+				},
+				Type:    &warn,
+				Reason:  pointer.StringPtr("BadStuff"),
+				Message: pointer.StringPtr("Bad stuff happened."),
+				Count:   func() *int { i := 42; return &i }(),
+				Source: &EventSource{
+					Component: pointer.StringPtr("that-thing"),
+				},
+				FirstTime: &now,
+				LastTime:  &now,
+			},
+		},
+		"Empty": {
+			reason: "Absent optional fields should be absent in our model",
+			s:      &corev1.Event{},
+			want: Event{
+				Metadata:  &ObjectMeta{},
+				FirstTime: &time.Time{},
+				LastTime:  &time.Time{},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GetEvent(tc.s)
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Event{}, "Raw")); diff != "" {
+				t.Errorf("\n%s\nGetEvent(...): -want, +got\n:%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/graph/model/generated.go
+++ b/internal/graph/model/generated.go
@@ -561,38 +561,6 @@ type CustomResourceValidation struct {
 	OpenAPIV3Schema *string `json:"openAPIV3Schema"`
 }
 
-// An event pertaining to a Kubernetes resource.
-type Event struct {
-	// An opaque identifier that is unique across all types.
-	ID ReferenceID `json:"id"`
-	// The underlying Kubernetes API version of this resource.
-	APIVersion string `json:"apiVersion"`
-	// The underlying Kubernetes API kind of this resource.
-	Kind string `json:"kind"`
-	// Metadata that is common to all Kubernetes API resources.
-	Metadata *ObjectMeta `json:"metadata"`
-	// The Kubernetes resource this event pertains to.
-	InvolvedObject KubernetesResource `json:"involvedObject"`
-	// The type of event.
-	Type *EventType `json:"type"`
-	// The reason the event was emitted.
-	Reason *string `json:"reason"`
-	// Details about the event, if any.
-	Message *string `json:"message"`
-	// The source of the event - e.g. a controller.
-	Source *EventSource `json:"source"`
-	// The number of times this event has occurred.
-	Count *int `json:"count"`
-	// The time at which this event was first recorded.
-	FirstTime *time.Time `json:"firstTime"`
-	// The time at which this event was most recently recorded.
-	LastTime *time.Time `json:"lastTime"`
-	// A raw JSON representation of the event.
-	Raw string `json:"raw"`
-}
-
-func (Event) IsNode() {}
-
 // An EventConnection represents a connection to events.
 type EventConnection struct {
 	// Connected nodes.

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/upbound/xgql/internal/auth"
 	"github.com/upbound/xgql/internal/graph/model"
@@ -21,7 +23,13 @@ type xrd struct {
 }
 
 func (r *xrd) Events(ctx context.Context, obj *model.CompositeResourceDefinition) (*model.EventConnection, error) {
-	return nil, nil
+	e := &events{clients: r.clients}
+	return e.Resolve(ctx, &corev1.ObjectReference{
+		APIVersion: obj.APIVersion,
+		Kind:       obj.Kind,
+		Name:       obj.Metadata.Name,
+		UID:        types.UID(obj.Metadata.UID),
+	})
 }
 
 func (r *xrd) DefinedCompositeResources(ctx context.Context, obj *model.CompositeResourceDefinition, version *string) (*model.CompositeResourceConnection, error) {

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -28,7 +29,13 @@ type configuration struct {
 }
 
 func (r *configuration) Events(ctx context.Context, obj *model.Configuration) (*model.EventConnection, error) {
-	return nil, nil
+	e := &events{clients: r.clients}
+	return e.Resolve(ctx, &corev1.ObjectReference{
+		APIVersion: obj.APIVersion,
+		Kind:       obj.Kind,
+		Name:       obj.Metadata.Name,
+		UID:        types.UID(obj.Metadata.UID),
+	})
 }
 
 func (r *configuration) Revisions(ctx context.Context, obj *model.Configuration, active *bool) (*model.ConfigurationRevisionConnection, error) {
@@ -79,7 +86,13 @@ type configurationRevision struct {
 }
 
 func (r *configurationRevision) Events(ctx context.Context, obj *model.ConfigurationRevision) (*model.EventConnection, error) {
-	return nil, nil
+	e := &events{clients: r.clients}
+	return e.Resolve(ctx, &corev1.ObjectReference{
+		APIVersion: obj.APIVersion,
+		Kind:       obj.Kind,
+		Name:       obj.Metadata.Name,
+		UID:        types.UID(obj.Metadata.UID),
+	})
 }
 
 type configurationRevisionStatus struct {

--- a/internal/graph/resolvers/event.go
+++ b/internal/graph/resolvers/event.go
@@ -1,0 +1,158 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/upbound/xgql/internal/auth"
+	"github.com/upbound/xgql/internal/graph/model"
+)
+
+const (
+	errListEvents    = "cannot list events"
+	errGetInvolved   = "cannot get involved resource"
+	errModelInvolved = "cannot model involved resource"
+)
+
+type events struct {
+	clients ClientCache
+}
+
+func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (*model.EventConnection, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	creds, _ := auth.FromContext(ctx)
+	c, err := r.clients.Get(creds)
+	if err != nil {
+		graphql.AddError(ctx, errors.Wrap(err, errGetClient))
+		return nil, nil
+	}
+
+	in := &corev1.EventList{}
+	if err := c.List(ctx, in); err != nil {
+		graphql.AddError(ctx, errors.Wrap(err, errListEvents))
+		return nil, nil
+	}
+
+	// If no involved object was supplied we want to fetch all events. This may
+	// include Kubernetes events that don't pertain to Crossplane.
+	if obj == nil {
+		out := &model.EventConnection{
+			Nodes:      make([]model.Event, 0, len(in.Items)),
+			TotalCount: len(in.Items),
+		}
+		for i := range in.Items {
+			out.Nodes = append(out.Nodes, model.GetEvent(&in.Items[i]))
+		}
+		return out, nil
+	}
+
+	out := &model.EventConnection{
+		Nodes: make([]model.Event, 0),
+	}
+
+	// NOTE(negz): The cache implementation we use has only basic support for
+	// field selectors, so we just filter our results here. Using the cache's
+	// rudimentary field selector support would require us to predeclare a set
+	// of event fields to index at cache load time, and even then we could only
+	// filter lists by a single field.
+	for i := range in.Items {
+		e := &in.Items[i] // To avoid taking the address of the range var.
+
+		// This event does not pertain to the involved object.
+		if !involves(e, obj) {
+			continue
+		}
+
+		out.Nodes = append(out.Nodes, model.GetEvent(e))
+		out.TotalCount++
+	}
+
+	return out, nil
+}
+
+func involves(e *corev1.Event, ref *corev1.ObjectReference) bool {
+	// The supplied object won't always have a UID, but the the event's object
+	// reference should. This test should be sufficient for most resolvers; the
+	// following logic is mostly for the case in which we're looking up events
+	// for a ReferenceID (which doesn't include the UID).
+	if ref.UID != "" {
+		return ref.UID == e.InvolvedObject.UID
+	}
+
+	// Note that because we don't know the supplied object's UID from here-on
+	// out we can't be sure whether we're returning events for the supplied
+	// object, or a different object with the same group, kind, namespace, and
+	// name from some time in the past.
+
+	got := ref
+	gotGV, err := schema.ParseGroupVersion(got.APIVersion)
+	if err != nil {
+		// This object has a malformed ID?
+		return false
+	}
+
+	want := e.InvolvedObject
+	wantGV, err := schema.ParseGroupVersion(want.APIVersion)
+	if err != nil {
+		// This event references a malformed APIVersion?
+		return false
+	}
+
+	switch {
+	// We match on group only because an event pertaining to one version of a
+	// resource pertains to all versions of a resource.
+	case gotGV.Group != wantGV.Group:
+		return false
+	case got.Kind != want.Kind:
+		return false
+	case got.Namespace != want.Namespace:
+		return false
+	case got.Name != want.Name:
+		return false
+	default:
+		return true
+	}
+}
+
+type event struct {
+	clients ClientCache
+}
+
+func (r *event) InvolvedObject(ctx context.Context, obj *model.Event) (model.KubernetesResource, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	creds, _ := auth.FromContext(ctx)
+	c, err := r.clients.Get(creds)
+	if err != nil {
+		graphql.AddError(ctx, errors.Wrap(err, errGetClient))
+		return nil, nil
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion(obj.InvolvedObjectRef.APIVersion)
+	u.SetKind(obj.InvolvedObjectRef.Kind)
+	nn := types.NamespacedName{
+		Namespace: obj.InvolvedObjectRef.Namespace,
+		Name:      obj.InvolvedObjectRef.Name,
+	}
+	if err := c.Get(ctx, nn, u); err != nil {
+		graphql.AddError(ctx, errors.Wrap(err, errGetInvolved))
+		return nil, nil
+	}
+
+	out, err := model.GetKubernetesResource(u)
+	if err != nil {
+		graphql.AddError(ctx, errors.Wrap(err, errModelInvolved))
+		return nil, nil
+	}
+	return out, nil
+}

--- a/internal/graph/resolvers/event_test.go
+++ b/internal/graph/resolvers/event_test.go
@@ -1,0 +1,352 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	"github.com/upbound/xgql/internal/auth"
+	"github.com/upbound/xgql/internal/clients"
+	"github.com/upbound/xgql/internal/graph/generated"
+	"github.com/upbound/xgql/internal/graph/model"
+)
+
+func TestEvent(t *testing.T) {
+	errBoom := errors.New("boom")
+	involved := &corev1.ObjectReference{UID: "deeply-involved"}
+
+	related := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "coolevent"},
+		InvolvedObject: corev1.ObjectReference{UID: involved.UID},
+	}
+
+	unrelated := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "coolevent"},
+		InvolvedObject: corev1.ObjectReference{UID: "wat"},
+	}
+
+	type args struct {
+		ctx      context.Context
+		involved *corev1.ObjectReference
+	}
+	type want struct {
+		ec   *model.EventConnection
+		err  error
+		errs gqlerror.List
+	}
+
+	cases := map[string]struct {
+		reason  string
+		clients ClientCache
+		args    args
+		want    want
+	}{
+		"GetClientError": {
+			reason: "If we can't get a client we should add the error to the GraphQL context and return early.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{}, errBoom
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+			},
+			want: want{
+				errs: gqlerror.List{
+					gqlerror.Errorf(errors.Wrap(errBoom, errGetClient).Error()),
+				},
+			},
+		},
+		"ListEventsError": {
+			reason: "If we can't list events we should add the error to the GraphQL context and return early.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockList: test.NewMockListFn(errBoom),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+			},
+			want: want{
+				errs: gqlerror.List{
+					gqlerror.Errorf(errors.Wrap(errBoom, errListEvents).Error()),
+				},
+			},
+		},
+		"ListAllEvents": {
+			reason: "We should successfully return events for all resources if the involved object is nil.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						*obj.(*corev1.EventList) = corev1.EventList{Items: []corev1.Event{related, unrelated}}
+						return nil
+					}),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+			},
+			want: want{
+				ec: &model.EventConnection{
+					Nodes:      []model.Event{model.GetEvent(&related), model.GetEvent(&unrelated)},
+					TotalCount: 2,
+				},
+			},
+		},
+		"ListEventsInvolving": {
+			reason: "We should successfully return events for all resources if the involved object is nil.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						*obj.(*corev1.EventList) = corev1.EventList{Items: []corev1.Event{related, unrelated}}
+						return nil
+					}),
+				}, nil
+			}),
+			args: args{
+				ctx:      graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				involved: involved,
+			},
+			want: want{
+				ec: &model.EventConnection{
+					Nodes:      []model.Event{model.GetEvent(&related)},
+					TotalCount: 1,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := &events{clients: tc.clients}
+
+			// Our GraphQL resolvers never return errors. We instead add an
+			// error to the GraphQL context and return early.
+			got, err := e.Resolve(tc.args.ctx, tc.args.involved)
+			errs := graphql.GetErrors(tc.args.ctx)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ns.Resolve(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ns.Resolve(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.ec, got); diff != "" {
+				t.Errorf("\n%s\ns.Resolve(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestInvolves(t *testing.T) {
+	wuid := &corev1.ObjectReference{UID: "so-unique"}
+
+	wid := &corev1.ObjectReference{
+		APIVersion: "example.org/v1",
+		Kind:       "Example",
+		Namespace:  "default",
+		Name:       "cool",
+	}
+
+	type args struct {
+		e *corev1.Event
+		o *corev1.ObjectReference
+	}
+
+	cases := map[string]struct {
+		args args
+		want bool
+	}{
+		"UIDMatch": {
+			args: args{
+				e: &corev1.Event{
+					InvolvedObject: corev1.ObjectReference{UID: wuid.UID},
+				},
+				o: wuid,
+			},
+			want: true,
+		},
+		"GroupMismatch": {
+			args: args{
+				e: &corev1.Event{
+					InvolvedObject: corev1.ObjectReference{
+						APIVersion: "other.net/v1",
+					},
+				},
+				o: wid,
+			},
+			want: false,
+		},
+		"KindMismatch": {
+			args: args{
+				e: &corev1.Event{
+					InvolvedObject: corev1.ObjectReference{
+						APIVersion: wid.APIVersion,
+						Kind:       "Other",
+					},
+				},
+				o: wid,
+			},
+			want: false,
+		},
+		"NamespaceMismatch": {
+			args: args{
+				e: &corev1.Event{
+					InvolvedObject: corev1.ObjectReference{
+						APIVersion: wid.APIVersion,
+						Kind:       wid.Kind,
+						Namespace:  "other",
+					},
+				},
+				o: wid,
+			},
+			want: false,
+		},
+		"NameMismatch": {
+			args: args{
+				e: &corev1.Event{
+					InvolvedObject: corev1.ObjectReference{
+						APIVersion: wid.APIVersion,
+						Kind:       wid.Kind,
+						Namespace:  wid.Namespace,
+						Name:       "other",
+					},
+				},
+				o: wid,
+			},
+			want: false,
+		},
+		"Match": {
+			args: args{
+				e: &corev1.Event{
+					InvolvedObject: corev1.ObjectReference{
+						APIVersion: wid.APIVersion,
+						Kind:       wid.Kind,
+						Namespace:  wid.Namespace,
+						Name:       wid.Name,
+					},
+				},
+				o: wid,
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := involves(tc.args.e, tc.args.o)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("involves(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+var _ generated.EventResolver = &event{}
+
+func TestEventInvolvedObject(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{})
+
+	type args struct {
+		ctx context.Context
+		obj *model.Event
+	}
+	type want struct {
+		kr   model.KubernetesResource
+		err  error
+		errs gqlerror.List
+	}
+
+	cases := map[string]struct {
+		reason  string
+		clients ClientCache
+		args    args
+		want    want
+	}{
+		"GetClientError": {
+			reason: "If we can't get a client we should add the error to the GraphQL context and return early.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{}, errBoom
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.Event{
+					InvolvedObjectRef: corev1.ObjectReference{},
+				},
+			},
+			want: want{
+				errs: gqlerror.List{
+					gqlerror.Errorf(errors.Wrap(errBoom, errGetClient).Error()),
+				},
+			},
+		},
+		"GetInvolvedError": {
+			reason: "If we can't get the involved object we should add the error to the GraphQL context and return early.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(errBoom),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.Event{
+					InvolvedObjectRef: corev1.ObjectReference{},
+				},
+			},
+			want: want{
+				errs: gqlerror.List{
+					gqlerror.Errorf(errors.Wrap(errBoom, errGetInvolved).Error()),
+				},
+			},
+		},
+		"Success": {
+			reason: "If we can get and model the involved object we should return it.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.Event{
+					InvolvedObjectRef: corev1.ObjectReference{},
+				},
+			},
+			want: want{
+				kr: gu,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := &event{clients: tc.clients}
+
+			// Our GraphQL resolvers never return errors. We instead add an
+			// error to the GraphQL context and return early.
+			got, err := s.InvolvedObject(tc.args.ctx, tc.args.obj)
+			errs := graphql.GetErrors(tc.args.ctx)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ns.InvolvedObject(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ns.InvolvedObject(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "Raw")); diff != "" {
+				t.Errorf("\n%s\ns.InvolvedObject(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,7 +28,13 @@ type provider struct {
 }
 
 func (r *provider) Events(ctx context.Context, obj *model.Provider) (*model.EventConnection, error) {
-	return nil, nil
+	e := &events{clients: r.clients}
+	return e.Resolve(ctx, &corev1.ObjectReference{
+		APIVersion: obj.APIVersion,
+		Kind:       obj.Kind,
+		Name:       obj.Metadata.Name,
+		UID:        types.UID(obj.Metadata.UID),
+	})
 }
 
 func (r *provider) Revisions(ctx context.Context, obj *model.Provider, active *bool) (*model.ProviderRevisionConnection, error) {
@@ -78,7 +85,13 @@ type providerRevision struct {
 }
 
 func (r *providerRevision) Events(ctx context.Context, obj *model.ProviderRevision) (*model.EventConnection, error) {
-	return nil, nil
+	e := &events{clients: r.clients}
+	return e.Resolve(ctx, &corev1.ObjectReference{
+		APIVersion: obj.APIVersion,
+		Kind:       obj.Kind,
+		Name:       obj.Metadata.Name,
+		UID:        types.UID(obj.Metadata.UID),
+	})
 }
 
 type providerRevisionStatus struct {

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 
@@ -86,4 +87,20 @@ func (r *query) CompositeResourceDefinitions(ctx context.Context, dangling *bool
 
 func (r *query) Compositions(ctx context.Context, dangling *bool) (*model.CompositionConnection, error) {
 	return nil, nil
+}
+
+func (r *query) Events(ctx context.Context, involvedID *model.ReferenceID) (*model.EventConnection, error) {
+	e := events{clients: r.clients}
+	if involvedID == nil {
+		// Resolve all events.
+		return e.Resolve(ctx, nil)
+	}
+
+	// Resolve events pertaining to the supplied ID.
+	return e.Resolve(ctx, &corev1.ObjectReference{
+		APIVersion: involvedID.APIVersion,
+		Kind:       involvedID.Kind,
+		Namespace:  involvedID.Namespace,
+		Name:       involvedID.Name,
+	})
 }

--- a/internal/graph/resolvers/root.go
+++ b/internal/graph/resolvers/root.go
@@ -49,7 +49,7 @@ func (r *Root) ObjectMeta() generated.ObjectMetaResolver {
 
 // Secret resolves properties of the Secret GraphQL type.
 func (r *Root) Secret() generated.SecretResolver {
-	return nil
+	return &secret{clients: r.clients}
 }
 
 // CompositeResource resolves properties of the CompositeResource GraphQL type.
@@ -117,12 +117,12 @@ func (r *Root) CustomResourceDefinition() generated.CustomResourceDefinitionReso
 
 // Event resolves properties of the Event GraphQL type.
 func (r *Root) Event() generated.EventResolver {
-	return nil
+	return &event{clients: r.clients}
 }
 
 // GenericResource resolves properties of the GenericResource GraphQL type.
 func (r *Root) GenericResource() generated.GenericResourceResolver {
-	return nil
+	return &genericResource{clients: r.clients}
 }
 
 // ManagedResource resolves properties of the CustomResourceDefinition GraphQL

--- a/schema/queries.gql
+++ b/schema/queries.gql
@@ -27,6 +27,14 @@ type Query {
       "Only return Compositions that aren't owned by a configuration revision."
       dangling: Boolean = false
     ): CompositionConnection!
+
+    """
+    Kubernetes events.
+    """
+    events(
+      "Only return events associated with the supplied ID."
+      involvedID: ID
+    ): EventConnection!
 }
 
 """


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/xgql/issues/13

This commit adds a generic Kubernetes event resolver that is used by all existing implementations of the KubernetesResource GraphQL interface (i.e. all existing resolvers that previously had stub 'events' methods). It also implements the GenericResource and Secret resolvers, because they only resolve events. A resolver _for_ (as opposed to of) events allows the involved object of an event to be resolved.

Furthermore, this commit adds a new 'events' query that can be used to query for events pertaining to a specific involved object by ID, or for all known events.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've spun up xgql and used the GraphQL playground to test that:

* The root `events` query can resolve events for all resources.
* The root `events` query can resolve events for a specific resource by its ID.
* The `events` resolver of various types (XRDs, configurations) can resolve their events.
* The resolved object of an event can be resolved.