### PR TITLE
Ensure connection arrays are stably sorted

### DIFF
--- a/internal/graph/model/sort.go
+++ b/internal/graph/model/sort.go
@@ -1,0 +1,120 @@
+package model
+
+func join(id ReferenceID) string {
+	return id.APIVersion + id.Kind + id.Namespace + id.Name
+}
+
+type identifiable interface{ id() ReferenceID }
+
+// All types that satisfy the KubernetesResource GraphQL interface must make
+// their ID available for sorting.
+func (r ManagedResource) id() ReferenceID             { return r.ID }
+func (r ProviderConfig) id() ReferenceID              { return r.ID }
+func (r CompositeResource) id() ReferenceID           { return r.ID }
+func (r CompositeResourceClaim) id() ReferenceID      { return r.ID }
+func (r Provider) id() ReferenceID                    { return r.ID }
+func (r ProviderRevision) id() ReferenceID            { return r.ID }
+func (r Configuration) id() ReferenceID               { return r.ID }
+func (r ConfigurationRevision) id() ReferenceID       { return r.ID }
+func (r CompositeResourceDefinition) id() ReferenceID { return r.ID }
+func (r Composition) id() ReferenceID                 { return r.ID }
+func (r CustomResourceDefinition) id() ReferenceID    { return r.ID }
+func (r Secret) id() ReferenceID                      { return r.ID }
+func (r ConfigMap) id() ReferenceID                   { return r.ID }
+func (r GenericResource) id() ReferenceID             { return r.ID }
+
+func (c *KubernetesResourceConnection) Len() int { return c.TotalCount }
+func (c *KubernetesResourceConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].(identifiable).id()) < join(c.Nodes[j].(identifiable).id())
+}
+func (c *KubernetesResourceConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *EventConnection) Len() int { return c.TotalCount }
+func (c *EventConnection) Less(i, j int) bool {
+
+	// We sort events by time, where possible.
+	it := c.Nodes[i].LastTime
+	jt := c.Nodes[j].LastTime
+	if it != nil && jt != nil {
+		return it.Before(*jt)
+	}
+
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *EventConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *ProviderConnection) Len() int { return c.TotalCount }
+func (c *ProviderConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *ProviderConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *ProviderRevisionConnection) Len() int { return c.TotalCount }
+func (c *ProviderRevisionConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *ProviderRevisionConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *CustomResourceDefinitionConnection) Len() int { return c.TotalCount }
+func (c *CustomResourceDefinitionConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *CustomResourceDefinitionConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *ConfigurationConnection) Len() int { return c.TotalCount }
+func (c *ConfigurationConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *ConfigurationConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *ConfigurationRevisionConnection) Len() int { return c.TotalCount }
+func (c *ConfigurationRevisionConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *ConfigurationRevisionConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *CompositeResourceDefinitionConnection) Len() int { return c.TotalCount }
+func (c *CompositeResourceDefinitionConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *CompositeResourceDefinitionConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *CompositionConnection) Len() int { return c.TotalCount }
+func (c *CompositionConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *CompositionConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *CompositeResourceConnection) Len() int { return c.TotalCount }
+func (c *CompositeResourceConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *CompositeResourceConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}
+
+func (c *CompositeResourceClaimConnection) Len() int { return c.TotalCount }
+func (c *CompositeResourceClaimConnection) Less(i, j int) bool {
+	return join(c.Nodes[i].ID) < join(c.Nodes[j].ID)
+}
+func (c *CompositeResourceClaimConnection) Swap(i, j int) {
+	c.Nodes[i], c.Nodes[j] = c.Nodes[j], c.Nodes[i]
+}

--- a/internal/graph/model/sort_test.go
+++ b/internal/graph/model/sort_test.go
@@ -1,0 +1,239 @@
+package model
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	_ identifiable = ManagedResource{}
+	_ identifiable = ProviderConfig{}
+	_ identifiable = CompositeResource{}
+	_ identifiable = CompositeResourceClaim{}
+	_ identifiable = Provider{}
+	_ identifiable = ProviderRevision{}
+	_ identifiable = Configuration{}
+	_ identifiable = ConfigurationRevision{}
+	_ identifiable = CompositeResourceDefinition{}
+	_ identifiable = Composition{}
+	_ identifiable = CustomResourceDefinition{}
+	_ identifiable = Secret{}
+	_ identifiable = ConfigMap{}
+	_ identifiable = GenericResource{}
+)
+
+var (
+	_ sort.Interface = &KubernetesResourceConnection{}
+	_ sort.Interface = &EventConnection{}
+	_ sort.Interface = &ProviderConnection{}
+	_ sort.Interface = &ProviderRevisionConnection{}
+	_ sort.Interface = &CustomResourceDefinitionConnection{}
+	_ sort.Interface = &ConfigurationConnection{}
+	_ sort.Interface = &ConfigurationRevisionConnection{}
+	_ sort.Interface = &CompositionConnection{}
+	_ sort.Interface = &CompositeResourceDefinitionConnection{}
+	_ sort.Interface = &CompositeResourceConnection{}
+	_ sort.Interface = &CompositeResourceClaimConnection{}
+)
+
+func TestSort(t *testing.T) {
+	now := time.Now()
+	soon := time.Now().Add(10 * time.Second)
+
+	cases := map[string]struct {
+		conn sort.Interface
+		want sort.Interface
+	}{
+		"KubernetesResourceConnection": {
+			conn: &KubernetesResourceConnection{
+				TotalCount: 2,
+				Nodes: []KubernetesResource{
+					GenericResource{ID: ReferenceID{Name: "b"}},
+					GenericResource{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &KubernetesResourceConnection{
+				TotalCount: 2,
+				Nodes: []KubernetesResource{
+					GenericResource{ID: ReferenceID{Name: "a"}},
+					GenericResource{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"EventConnection": {
+			conn: &EventConnection{
+				TotalCount: 3,
+				Nodes: []Event{
+					{ID: ReferenceID{Name: "b"}, LastTime: &soon},
+					{ID: ReferenceID{Name: "a"}, LastTime: &now},
+					{ID: ReferenceID{Name: "c"}},
+				},
+			},
+			want: &EventConnection{
+				TotalCount: 3,
+				Nodes: []Event{
+					{ID: ReferenceID{Name: "a"}, LastTime: &now},
+					{ID: ReferenceID{Name: "b"}, LastTime: &soon},
+					{ID: ReferenceID{Name: "c"}},
+				},
+			},
+		},
+		"ProviderConnection": {
+			conn: &ProviderConnection{
+				TotalCount: 2,
+				Nodes: []Provider{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &ProviderConnection{
+				TotalCount: 2,
+				Nodes: []Provider{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"ProviderRevisionConnection": {
+			conn: &ProviderRevisionConnection{
+				TotalCount: 2,
+				Nodes: []ProviderRevision{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &ProviderRevisionConnection{
+				TotalCount: 2,
+				Nodes: []ProviderRevision{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"CustomResourceDefinitionConnection": {
+			conn: &CustomResourceDefinitionConnection{
+				TotalCount: 2,
+				Nodes: []CustomResourceDefinition{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &CustomResourceDefinitionConnection{
+				TotalCount: 2,
+				Nodes: []CustomResourceDefinition{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"ConfigurationConnection": {
+			conn: &ConfigurationConnection{
+				TotalCount: 2,
+				Nodes: []Configuration{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &ConfigurationConnection{
+				TotalCount: 2,
+				Nodes: []Configuration{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"ConfigurationRevisionConnection": {
+			conn: &ConfigurationRevisionConnection{
+				TotalCount: 2,
+				Nodes: []ConfigurationRevision{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &ConfigurationRevisionConnection{
+				TotalCount: 2,
+				Nodes: []ConfigurationRevision{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"CompositionConnection": {
+			conn: &CompositionConnection{
+				TotalCount: 2,
+				Nodes: []Composition{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &CompositionConnection{
+				TotalCount: 2,
+				Nodes: []Composition{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"CompositeResourceDefinitionConnection": {
+			conn: &CompositeResourceDefinitionConnection{
+				TotalCount: 2,
+				Nodes: []CompositeResourceDefinition{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &CompositeResourceDefinitionConnection{
+				TotalCount: 2,
+				Nodes: []CompositeResourceDefinition{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"CompositeResourceConnection": {
+			conn: &CompositeResourceConnection{
+				TotalCount: 2,
+				Nodes: []CompositeResource{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &CompositeResourceConnection{
+				TotalCount: 2,
+				Nodes: []CompositeResource{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+		"CompositeResourceClaimConnection": {
+			conn: &CompositeResourceClaimConnection{
+				TotalCount: 2,
+				Nodes: []CompositeResourceClaim{
+					{ID: ReferenceID{Name: "b"}},
+					{ID: ReferenceID{Name: "a"}},
+				},
+			},
+			want: &CompositeResourceClaimConnection{
+				TotalCount: 2,
+				Nodes: []CompositeResourceClaim{
+					{ID: ReferenceID{Name: "a"}},
+					{ID: ReferenceID{Name: "b"}},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sort.Stable(tc.conn)
+			if diff := cmp.Diff(tc.want, tc.conn); diff != "" {
+				t.Errorf("sort.Stable(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -76,6 +77,7 @@ func (r *xrd) DefinedCompositeResources(ctx context.Context, obj *model.Composit
 		out.Nodes = append(out.Nodes, model.GetCompositeResource(&in.Items[i]))
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -131,6 +133,7 @@ func (r *xrd) DefinedCompositeResourceClaims(ctx context.Context, obj *model.Com
 		out.Nodes = append(out.Nodes, model.GetCompositeResourceClaim(&in.Items[i]))
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 

--- a/internal/graph/resolvers/common.go
+++ b/internal/graph/resolvers/common.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -132,6 +133,7 @@ func (r *crd) DefinedResources(ctx context.Context, obj *model.CustomResourceDef
 		out.Nodes = append(out.Nodes, kr)
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -180,6 +181,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -72,6 +73,7 @@ func (r *configuration) Revisions(ctx context.Context, obj *model.Configuration)
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 

--- a/internal/graph/resolvers/event.go
+++ b/internal/graph/resolvers/event.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -50,6 +51,8 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (*mod
 		for i := range in.Items {
 			out.Nodes = append(out.Nodes, model.GetEvent(&in.Items[i]))
 		}
+
+		sort.Stable(sort.Reverse(out))
 		return out, nil
 	}
 
@@ -74,6 +77,7 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (*mod
 		out.TotalCount++
 	}
 
+	sort.Stable(sort.Reverse(out))
 	return out, nil
 }
 

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -71,6 +72,7 @@ func (r *provider) Revisions(ctx context.Context, obj *model.Provider) (*model.P
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -108,6 +109,7 @@ func (r *query) KubernetesResources(ctx context.Context, apiVersion, kind string
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -197,6 +199,7 @@ func (r *query) Providers(ctx context.Context) (*model.ProviderConnection, error
 		out.Nodes = append(out.Nodes, model.GetProvider(&in.Items[i]))
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -238,6 +241,7 @@ func (r *query) ProviderRevisions(ctx context.Context, provider *model.Reference
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -274,6 +278,7 @@ func (r *query) CustomResourceDefinitions(ctx context.Context, revision *model.R
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -303,6 +308,7 @@ func (r *query) Configurations(ctx context.Context) (*model.ConfigurationConnect
 		out.Nodes = append(out.Nodes, model.GetConfiguration(&in.Items[i]))
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -344,6 +350,7 @@ func (r *query) ConfigurationRevisions(ctx context.Context, configuration *model
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -385,6 +392,7 @@ func (r *query) CompositeResourceDefinitions(ctx context.Context, revision *mode
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 
@@ -426,6 +434,7 @@ func (r *query) Compositions(ctx context.Context, revision *model.ReferenceID, d
 		out.TotalCount++
 	}
 
+	sort.Stable(out)
 	return out, nil
 }
 

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -696,7 +696,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 			},
 			want: want{
 				pc: &model.ProviderRevisionConnection{
-					Nodes:      []model.ProviderRevision{gother, gactive, ginactive},
+					Nodes:      []model.ProviderRevision{gactive, ginactive, gother},
 					TotalCount: 3,
 				},
 			},
@@ -1145,7 +1145,7 @@ func TestQueryConfigurationRevisions(t *testing.T) {
 			},
 			want: want{
 				pc: &model.ConfigurationRevisionConnection{
-					Nodes:      []model.ConfigurationRevision{gother, gactive, ginactive},
+					Nodes:      []model.ConfigurationRevision{gactive, ginactive, gother},
 					TotalCount: 3,
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/xgql/issues/45

Some of the node arrays returned by xgql are built from a Kubernetes client-go cache. This cache is backed by a map, which returns elements in random order when ranged over. This commit ensures we return such arrays sorted by ID (e.g. GVK, namespace, and name). Note that connections which are not backed by a cache list (e.g. connections that are populated by ranging over an ordered array of references) are not sorted.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
