### PR TITLE
Expose CustomResourceDefinition scopes

### DIFF
--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -335,6 +335,7 @@ type ComplexityRoot struct {
 	CustomResourceDefinitionSpec struct {
 		Group    func(childComplexity int) int
 		Names    func(childComplexity int) int
+		Scope    func(childComplexity int) int
 		Versions func(childComplexity int) int
 	}
 
@@ -1836,6 +1837,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CustomResourceDefinitionSpec.Names(childComplexity), true
+
+	case "CustomResourceDefinitionSpec.scope":
+		if e.complexity.CustomResourceDefinitionSpec.Scope == nil {
+			break
+		}
+
+		return e.complexity.CustomResourceDefinitionSpec.Scope(childComplexity), true
 
 	case "CustomResourceDefinitionSpec.versions":
 		if e.complexity.CustomResourceDefinitionSpec.Versions == nil {
@@ -3852,6 +3860,11 @@ type CustomResourceDefinitionSpec {
   names: CustomResourceDefinitionNames!
 
   """
+  Scope of the defined custom resource.
+  """
+  scope: ResourceScope!
+
+  """
   Versions is the list of all API versions of the defined custom resource.
   Version names are used to compute the order in which served versions are
   listed in API discovery. If the version string is "kube-like", it will sort
@@ -3864,6 +3877,24 @@ type CustomResourceDefinitionSpec {
   v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
   """
   versions: [CustomResourceDefinitionVersion!]
+}
+
+"""
+ResourceScope defines the scopes available to custom resources.
+"""
+enum ResourceScope {
+  """
+  Cluster scoped resources exist outside any namespace. The combination of their
+  API version, kind, and name must be unique within a cluster.
+  """
+  CLUSTER_SCOPED
+
+  """
+  Namespace scoped resources exist within a particular namespace. The
+  combination of their API version, kind, and name must be unique only within
+  their namespace.
+  """
+  NAMESPACE_SCOPED
 }
 
 """
@@ -10956,6 +10987,41 @@ func (ec *executionContext) _CustomResourceDefinitionSpec_names(ctx context.Cont
 	res := resTmp.(*model.CustomResourceDefinitionNames)
 	fc.Result = res
 	return ec.marshalNCustomResourceDefinitionNames2ᚖgithubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐCustomResourceDefinitionNames(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CustomResourceDefinitionSpec_scope(ctx context.Context, field graphql.CollectedField, obj *model.CustomResourceDefinitionSpec) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CustomResourceDefinitionSpec",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Scope, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ResourceScope)
+	fc.Result = res
+	return ec.marshalNResourceScope2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐResourceScope(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CustomResourceDefinitionSpec_versions(ctx context.Context, field graphql.CollectedField, obj *model.CustomResourceDefinitionSpec) (ret graphql.Marshaler) {
@@ -19190,6 +19256,11 @@ func (ec *executionContext) _CustomResourceDefinitionSpec(ctx context.Context, s
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "scope":
+			out.Values[i] = ec._CustomResourceDefinitionSpec_scope(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "versions":
 			out.Values[i] = ec._CustomResourceDefinitionSpec_versions(ctx, field, obj)
 		default:
@@ -21459,6 +21530,16 @@ func (ec *executionContext) marshalNProviderSpec2ᚖgithubᚗcomᚋupboundᚋxgq
 		return graphql.Null
 	}
 	return ec._ProviderSpec(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNResourceScope2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐResourceScope(ctx context.Context, v interface{}) (model.ResourceScope, error) {
+	var res model.ResourceScope
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNResourceScope2githubᚗcomᚋupboundᚋxgqlᚋinternalᚋgraphᚋmodelᚐResourceScope(ctx context.Context, sel ast.SelectionSet, v model.ResourceScope) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -251,6 +251,18 @@ func GetCustomResourceDefinitionNames(in kextv1.CustomResourceDefinitionNames) *
 	return out
 }
 
+// GetResourceScope from the suppled Kubernetes scope.
+func GetResourceScope(in kextv1.ResourceScope) ResourceScope {
+	switch in {
+	case kextv1.ClusterScoped:
+		return ResourceScopeClusterScoped
+	case kextv1.NamespaceScoped:
+		return ResourceScopeNamespaceScoped
+	default:
+		return ""
+	}
+}
+
 // GetCustomResourceDefinitionVersions from the supplied Kubernetes versions.
 func GetCustomResourceDefinitionVersions(in []kextv1.CustomResourceDefinitionVersion) []CustomResourceDefinitionVersion {
 	if in == nil {
@@ -320,6 +332,7 @@ func GetCustomResourceDefinition(crd *kextv1.CustomResourceDefinition) CustomRes
 		Spec: &CustomResourceDefinitionSpec{
 			Group:    crd.Spec.Group,
 			Names:    GetCustomResourceDefinitionNames(crd.Spec.Names),
+			Scope:    GetResourceScope(crd.Spec.Scope),
 			Versions: GetCustomResourceDefinitionVersions(crd.Spec.Versions),
 		},
 		Status:       GetCustomResourceDefinitionStatus(crd.Status),

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -299,6 +299,7 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 						ListKind:   "ClusterExampleList",
 						Categories: []string{"example"},
 					},
+					Scope: kextv1.NamespaceScoped,
 					Versions: []kextv1.CustomResourceDefinitionVersion{{
 						Name:   "v1",
 						Served: true,
@@ -337,6 +338,7 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 						ListKind:   pointer.StringPtr("ClusterExampleList"),
 						Categories: []string{"example"},
 					},
+					Scope: ResourceScopeNamespaceScoped,
 					Versions: []CustomResourceDefinitionVersion{{
 						Name:   "v1",
 						Served: true,

--- a/internal/graph/model/generated.go
+++ b/internal/graph/model/generated.go
@@ -542,6 +542,8 @@ type CustomResourceDefinitionSpec struct {
 	Group string `json:"group"`
 	// Names specifies the resource and kind names of the defined custom resource.
 	Names *CustomResourceDefinitionNames `json:"names"`
+	// Scope of the defined custom resource.
+	Scope ResourceScope `json:"scope"`
 	// Versions is the list of all API versions of the defined custom resource.
 	// Version names are used to compute the order in which served versions are
 	// listed in API discovery. If the version string is "kube-like", it will sort
@@ -1160,6 +1162,53 @@ func (e *PackageRevisionDesiredState) UnmarshalGQL(v interface{}) error {
 }
 
 func (e PackageRevisionDesiredState) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// ResourceScope defines the scopes available to custom resources.
+type ResourceScope string
+
+const (
+	// Cluster scoped resources exist outside any namespace. The combination of their
+	// API version, kind, and name must be unique within a cluster.
+	ResourceScopeClusterScoped ResourceScope = "CLUSTER_SCOPED"
+	// Namespace scoped resources exist within a particular namespace. The
+	// combination of their API version, kind, and name must be unique only within
+	// their namespace.
+	ResourceScopeNamespaceScoped ResourceScope = "NAMESPACE_SCOPED"
+)
+
+var AllResourceScope = []ResourceScope{
+	ResourceScopeClusterScoped,
+	ResourceScopeNamespaceScoped,
+}
+
+func (e ResourceScope) IsValid() bool {
+	switch e {
+	case ResourceScopeClusterScoped, ResourceScopeNamespaceScoped:
+		return true
+	}
+	return false
+}
+
+func (e ResourceScope) String() string {
+	return string(e)
+}
+
+func (e *ResourceScope) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ResourceScope(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ResourceScope", str)
+	}
+	return nil
+}
+
+func (e ResourceScope) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/schema/common.gql
+++ b/schema/common.gql
@@ -523,6 +523,11 @@ type CustomResourceDefinitionSpec {
   names: CustomResourceDefinitionNames!
 
   """
+  Scope of the defined custom resource.
+  """
+  scope: ResourceScope!
+
+  """
   Versions is the list of all API versions of the defined custom resource.
   Version names are used to compute the order in which served versions are
   listed in API discovery. If the version string is "kube-like", it will sort
@@ -535,6 +540,24 @@ type CustomResourceDefinitionSpec {
   v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
   """
   versions: [CustomResourceDefinitionVersion!]
+}
+
+"""
+ResourceScope defines the scopes available to custom resources.
+"""
+enum ResourceScope {
+  """
+  Cluster scoped resources exist outside any namespace. The combination of their
+  API version, kind, and name must be unique within a cluster.
+  """
+  CLUSTER_SCOPED
+
+  """
+  Namespace scoped resources exist within a particular namespace. The
+  combination of their API version, kind, and name must be unique only within
+  their namespace.
+  """
+  NAMESPACE_SCOPED
 }
 
 """


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This allows callers to determine the scope (e.g. namespaced or cluster scoped) of a particular custom resource.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
I've listed all CRDs and confirmed they have a scope field.