### PR TITLE
Perform API discovery more aggressively, but less frequently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/sdk v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v0.19.0
 	go.opentelemetry.io/otel/trace v0.19.0
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.20.2
 	k8s.io/apiextensions-apiserver v0.20.1


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/xgql/issues/50

This commit reduces the time it takes to perform API discovery on a kind cluster with a moderate number of API endpoints (three providers with ~120 total CRDs installed) from ~16 seconds to ~40ms. It does so by dramatically raising API discovery rate limits, from 5qps with a 10qps burst to 20qps with a 100qps burst.

To compensate for this, it also restricts discovery to happening no more than once every 20 seconds, rather than up to 5 times per second. Discovery happens once on startup, and then once any time a client requests a kind of API resource that did not exist last time discovery was performed (e.g. because a provider has installed new CRDs since). The implementation of the underlying Dynamic REST mapper means that discovery results are now effectively cached for 20 seconds.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've confirmed that API discovery now completes _much_ faster both on startup and when a client requests a previously undiscovered kind of API resource. I've also confirmed that discovery is effectively cached for 20 seconds by adding some debug statements to controller-runtime and verifying that discovery doesn't run any more frequently than every 20 seconds, even when I aggressively make GraphQL queries to list an unknown kind of resource.