### PR TITLE
Don't timeout REST connections after 5 seconds

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -56,7 +56,6 @@ func Config() (*rest.Config, error) {
 	cfg.QPS = 5
 	cfg.Burst = 20
 
-	cfg.Timeout = 5 * time.Second
 	cfg.UserAgent = "xgql/" + version.Version
 
 	return cfg, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I suspect this is causing watches to timeout after 5 seconds (in some situations), which is definitely not what we want.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

@thephred are you able to test whether this resolves the timeout issue you saw introduced with https://github.com/upbound/xgql/pull/51? I suspect this is the culprit but I haven't been able to reproduce the issue.