### PR TITLE
Return uppercase status condition enums

### DIFF
--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -48,6 +48,20 @@ func UnmarshalStringMap(v interface{}) (map[string]string, error) {
 	return nil, errors.Errorf("%T is not a map", v)
 }
 
+// GetConditionStatus from the supplied Crossplane status.
+func GetConditionStatus(s corev1.ConditionStatus) ConditionStatus {
+	switch s {
+	case corev1.ConditionTrue:
+		return ConditionStatusTrue
+	case corev1.ConditionFalse:
+		return ConditionStatusFalse
+	case corev1.ConditionUnknown:
+		return ConditionStatusUnknown
+	default:
+		return ConditionStatus(s)
+	}
+}
+
 // GetConditions from the supplied Crossplane conditions.
 func GetConditions(in []xpv1.Condition) []Condition {
 	if in == nil {
@@ -60,7 +74,7 @@ func GetConditions(in []xpv1.Condition) []Condition {
 
 		out[i] = Condition{
 			Type:               string(c.Type),
-			Status:             ConditionStatus(c.Status),
+			Status:             GetConditionStatus(c.Status),
 			LastTransitionTime: c.LastTransitionTime.Time,
 			Reason:             string(c.Reason),
 		}
@@ -298,7 +312,7 @@ func GetCustomResourceDefinitionConditions(in []kextv1.CustomResourceDefinitionC
 
 		out[i] = Condition{
 			Type:               string(c.Type),
-			Status:             ConditionStatus(c.Status),
+			Status:             GetConditionStatus(corev1.ConditionStatus(c.Status)),
 			LastTransitionTime: c.LastTransitionTime.Time,
 			Reason:             c.Reason,
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/upbound/xgql/issues/54

Previously we were returning values that were at odds with our schema.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've queried for conditions and confirmed their status enums are now uppercase per the schema:

```json
{
  "data": {
    "kubernetesResource": {
      "definedResources": {
        "totalCount": 1,
        "nodes": [
          {
            "id": "S1PuVzs4XE5dJC3_A1NRTC4mVmk5S205PEL-ar9COVZdXEJ3",
            "apiVersion": "database.gcp.crossplane.io/v1beta1",
            "kind": "CloudSQLInstance",
            "metadata": {
              "name": "my-db-tnjxn-mpgnv"
            },
            "status": {
              "conditions": [
                {
                  "reason": "Available",
                  "status": "TRUE",
                  "message": null,
                  "lastTransitionTime": "2021-04-28T23:00:59Z"
                },
                {
                  "reason": "ReconcileSuccess",
                  "status": "TRUE",
                  "message": null,
                  "lastTransitionTime": "2021-04-28T22:57:57Z"
                }
              ]
            }
          }
        ]
      }
    }
  },
  "extensions": {}
}
```