### PR TITLE
[release-0.1] Improve the heuristics we use to identify resource types

### DIFF
--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -363,8 +363,6 @@ func GetKubernetesResource(u *kunstructured.Unstructured) (KubernetesResource, e
 	// This isn't _really_ that complex; it's a long but simple switch.
 
 	switch {
-	case unstructured.ProbablyManaged(u):
-		return GetManagedResource(u), nil
 
 	case unstructured.ProbablyProviderConfig(u):
 		return GetProviderConfig(u), nil
@@ -374,6 +372,14 @@ func GetKubernetesResource(u *kunstructured.Unstructured) (KubernetesResource, e
 
 	case unstructured.ProbablyClaim(u):
 		return GetCompositeResourceClaim(u), nil
+
+	// Note that order is important here. We want to check whether the resource
+	// seems to be a managed resource _after_ checking whether it seems to be a
+	// composite resource because it's possible to define a composite resource
+	// that would pass the ProbablyManaged check. Such a composite resource
+	// would very likely pass the ProbablyComposite check and never reach this.
+	case unstructured.ProbablyManaged(u):
+		return GetManagedResource(u), nil
 
 	case u.GroupVersionKind() == pkgv1.ProviderGroupVersionKind:
 		p := &pkgv1.Provider{}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -499,6 +499,7 @@ func TestGetKubernetesResource(t *testing.T) {
 			u: func() *kunstructured.Unstructured {
 				// Set resource refs to convince unstructured.ProbablyClaim
 				xrc := &unstructured.Claim{}
+				xrc.SetNamespace("default")
 				xrc.SetName("cool")
 				xrc.SetCompositionReference(&corev1.ObjectReference{Name: "cmp"})
 				xrc.SetResourceReference(&corev1.ObjectReference{Name: "xr"})
@@ -506,8 +507,14 @@ func TestGetKubernetesResource(t *testing.T) {
 			}(),
 			want: want{
 				kr: CompositeResourceClaim{
-					ID:       ReferenceID{Name: "cool"},
-					Metadata: &ObjectMeta{Name: "cool"},
+					ID: ReferenceID{
+						Namespace: "default",
+						Name:      "cool",
+					},
+					Metadata: &ObjectMeta{
+						Namespace: pointer.StringPtr("default"),
+						Name:      "cool",
+					},
 					Spec: &CompositeResourceClaimSpec{
 						CompositionReference: &corev1.ObjectReference{Name: "cmp"},
 						ResourceReference:    &corev1.ObjectReference{Name: "xr"},

--- a/internal/unstructured/managed.go
+++ b/internal/unstructured/managed.go
@@ -8,9 +8,15 @@ import (
 )
 
 // ProbablyManaged returns true if the supplied *Unstructured is probably a
-// managed resource. It considers any resource with a string value at field path
-// spec.providerConfigRef.name to probably be a managed resource.
+// managed resource. It considers any cluster scoped resource with a string
+// value at field path spec.providerConfigRef.name to probably be a managed
+// resource. spec.providerConfigRef is technically optional, but is defaulted at
+// create time by the CRD's OpenAPI schema.
 func ProbablyManaged(u *unstructured.Unstructured) bool {
+	if u.GetNamespace() != "" {
+		return false
+	}
+
 	_, err := fieldpath.Pave(u.Object).GetString("spec.providerConfigRef.name")
 	return err == nil
 }

--- a/internal/unstructured/providerconfig.go
+++ b/internal/unstructured/providerconfig.go
@@ -8,10 +8,10 @@ import (
 )
 
 // ProbablyProviderConfig returns true if the supplied *Unstructured is probably
-// a provider config. It considers any resource of kind: ProviderConfig to
-// probably be a provider config.
+// a provider config. It considers any cluster scoped resource of kind:
+// ProviderConfig to probably be a provider config.
 func ProbablyProviderConfig(u *unstructured.Unstructured) bool {
-	return u.GetKind() == "ProviderConfig"
+	return u.GetNamespace() == "" && u.GetKind() == "ProviderConfig"
 }
 
 // A ProviderConfig resource.


### PR DESCRIPTION


<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Backport of https://github.com/upbound/xgql/pull/60

This makes GetKubernetesResource a little more robust in the face of ambiguous resources, for example an XR that has a composition selector set but that is not able to set its composition ref because no composition matches.

These heuristics are still flawed; for example we would be unable to identify a pathological XR with no compositionRef, compositionSelector, or resourceRefs.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

See https://github.com/upbound/xgql/pull/60