### PR TITLE
Propagate API server error metadata to GraphQL callers

### DIFF
--- a/internal/graph/present/present.go
+++ b/internal/graph/present/present.go
@@ -21,10 +21,32 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	errRBAC = "possible RBAC permissions error"
+)
+
+// Error extension fields.
+const (
+	// Source reflects the 'source' of an error.
+	Source = "source"
+
+	// Reason reflects the 'reason' for an error.
+	Reason = "reason"
+
+	// Code is the error code, if any.
+	Code = "code"
+)
+
+// An ErrorSource indicates where an error originated.
+type ErrorSource string
+
+// Error sources.
+const (
+	ErrorSourceUnknown   ErrorSource = "Unknown"
+	ErrorSourceAPIServer ErrorSource = "APIServer"
 )
 
 // wrap adds context to a *gqlerror.Error message while maintaining metadata
@@ -39,8 +61,31 @@ func wrap(err error, message string) error {
 	return gerr
 }
 
+// Extend an error with GraphQL extensions.
+func Extend(ctx context.Context, err error, ext map[string]interface{}) *gqlerror.Error {
+	// 'Upgrade' the error to a GraphQL error if it isn't one already. We know
+	// the returned error won't be wrapped.
+	//nolint:errorlint
+	gerr := graphql.ErrorOnPath(ctx, err).(*gqlerror.Error)
+	if gerr.Extensions == nil {
+		gerr.Extensions = ext
+		return gerr
+	}
+	for k, v := range ext {
+		gerr.Extensions[k] = v
+	}
+	return gerr
+}
+
 // Error 'presents' errors encountered by GraphQL resolvers.
 func Error(ctx context.Context, err error) *gqlerror.Error {
+	s := kerrors.APIStatus(nil)
+
+	// This does not appear to be an error from the API server.
+	if !errors.As(err, &s) {
+		return Extend(ctx, err, map[string]interface{}{Source: ErrorSourceUnknown})
+	}
+
 	// Most xgql resolvers read from a controller-runtime cache that is hydrated
 	// by taking a watch on any type they're asked to read. The cache uses the
 	// credentials passed in by the caller, and will never start if those
@@ -50,12 +95,13 @@ func Error(ctx context.Context, err error) *gqlerror.Error {
 	// failing to sync". The most common reason a cache won't start is because
 	// the caller doesn't have RBAC permissions to list or watch the desired
 	// type, so we wrap the error with a hint.
-	if kerrors.IsTimeout(err) {
+	if s.Status().Reason == metav1.StatusReasonTimeout {
 		err = wrap(err, errRBAC)
 	}
 
-	// ErrorOnPath will 'upgrade' the supplied error to a GraphQL error if it
-	// wasn't one already.
-	err = graphql.ErrorOnPath(ctx, err)
-	return err.(*gqlerror.Error) //nolint:errorlint // We know err will be a *graphql.Error.
+	return Extend(ctx, err, map[string]interface{}{
+		Source: ErrorSourceAPIServer,
+		Reason: s.Status().Reason,
+		Code:   s.Status().Code,
+	})
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve xgql!

Please read through https://git.io/fj2m9 if this is your first time opening a
xgql pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open xgql issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This decorates GraphQL errors with a source (either the API server, or unknown). If the error comes from the API server, we bubble up the code/reason for the error, according to the API server.

I have:

- [x] Read and followed xgql's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've tested a few failure cases to ensure we have the error extensions we expect:

Creating a Secret in a non-existent namespace:
```json
{
  "errors": [
    {
      "message": "cannot create Kubernetes resource: namespaces \"wat\" not found",
      "path": [
        "createKubernetesResource"
      ],
      "extensions": {
        "code": 404,
        "reason": "NotFound",
        "source": "APIServer"
      }
    }
  ],
  "data": null,
  "extensions": {}
}
```

Creating a `Bucket` with no spec:

```json
{
  "errors": [
    {
      "message": "cannot create Kubernetes resource: Bucket.storage.gcp.crossplane.io \"test\" is invalid: spec: Required value",
      "path": [
        "createKubernetesResource"
      ],
      "extensions": {
        "code": 422,
        "reason": "Invalid",
        "source": "APIServer"
      }
    }
  ],
  "data": null,
  "extensions": {}
}
```