### PR TITLE
Compress HTTP reponses

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -131,6 +131,7 @@ func main() {
 
 	rt := chi.NewRouter()
 	rt.Use(middleware.RequestLogger(&formatter{log}))
+	rt.Use(middleware.Compress(5)) // Chi recommends compression level 5.
 	rt.Use(auth.Middleware)
 	rt.Use(version.Middleware)
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes https://github.com/upbound/xgql/issues/72

This commit adds a chi middleware that compresses certain content types (including the JSON returned by GraphQL queries) using gzip.


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I've used the playground to make some queries and validated that the responses I get are gzipped.

<img width="285" alt="gzip" src="https://user-images.githubusercontent.com/1049349/120542942-9102de00-c3a0-11eb-8d66-032e30062ed6.png">

