### PR TITLE
Create a token secret for our service account

### DIFF
--- a/cluster/local/service-account.yaml
+++ b/cluster/local/service-account.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: default
+  name: xgql-testing
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: default
+  name: xgql-testing
+  annotations:
+    kubernetes.io/service-account.name: "xgql-testing"
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xgql-testing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-admin
+subjects:
+- kind: ServiceAccount
+  namespace: default
+  name: xgql-testing


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Kubernetes used to do this automatically, but now you need to manually create a service account token secret. There's no way to do this using the CLI that I can find, so let's just create it using a YAML manifest.

https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I've tested the flow on my laptop.