### PR TITLE
Use Go 1.19 to build xgql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.18'
-  GOLANGCI_VERSION: 'v1.47.1'
+  GO_VERSION: '1.19'
+  GOLANGCI_VERSION: 'v1.49'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
@@ -46,6 +46,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+      
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Find the Go Build Cache
         id: go
@@ -68,10 +73,9 @@ jobs:
       - name: Vendor Dependencies
         run: make vendor vendor.check
 
-      # This action uses its own setup-go, which always seems to use the latest
-      # stable version of Go. We could run 'make lint' to ensure our desired Go
-      # version, but we prefer this action because it leaves 'annotations' (i.e.
-      # it comments on PRs to point out linter violations).
+      # We could run 'make lint' to ensure our desired Go version, but we prefer
+      # this action because it leaves 'annotations' (i.e. it comments on PRs to
+      # point out linter violations).
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,7 +108,6 @@ linters:
     - govet
     - gocyclo
     - gocritic
-    - interfacer
     - goconst
     - goimports
     - gofmt  # We enable this as well as goimports for its simplify mode.
@@ -117,6 +116,15 @@ linters:
     - unconvert
     - misspell
     - nakedret
+
+  disable:
+    # These linters are all deprecated as of golangci-lint v1.49.0. We disable
+    # them explicitly to avoid the linter logging deprecation warnings.
+    - deadcode
+    - varcheck
+    - scopelint
+    - structcheck
+    - interfacer
 
   presets:
     - bugs

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ PLATFORMS ?= linux_amd64 linux_arm64
 
 # Setup Go
 NPROCS ?= 1
+GO_REQUIRED_VERSION = 1.19
+GOLANGCILINT_VERSION = 1.49.0
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/${PROJECT_NAME}
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)

--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"net/http"
 	"os"
@@ -161,6 +161,7 @@ func main() {
 	// client-go machinery, so instead we just log it. The errors will persist
 	// until they are resolved (e.g. the user is granted the RBAC access they
 	// need) or the cache expires.
+	//nolint:reassign
 	utilruntime.ErrorHandlers = []func(error){func(err error) { log.Debug("Kubernetes runtime error", "err", err) }}
 
 	rt := chi.NewRouter()
@@ -214,7 +215,7 @@ func main() {
 		WriteTimeout:      10 * time.Second,
 		ReadTimeout:       5 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
-		ErrorLog:          stdlog.New(ioutil.Discard, "", 0),
+		ErrorLog:          stdlog.New(io.Discard, "", 0),
 	}
 
 	if *tlsCert != "" && *tlsKey != "" {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/xgql
 
-go 1.18
+go 1.19
 
 require (
 	github.com/99designs/gqlgen v0.17.13

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -75,6 +75,7 @@ func (c Credentials) Inject(cfg *rest.Config) *rest.Config {
 
 // Hash returns a SHA-256 hash of the supplied credentials, plus any extra bytes
 // that were supplied.
+//
 //nolint:errcheck // Writing to a hash never returns an error.
 func (c Credentials) Hash(extra []byte) string {
 	h := sha256.New()


### PR DESCRIPTION
### Description of your changes

Use Go 1.19 to build xgql and address the issues revealed by updating to golangci-lint v1.49.0

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Ran `make` and `make reviewable`
