### PR TITLE
Fix trailing space on helm chart URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GO111MODULE = on
 
 # Setup Helm
 USE_HELM3 = true
-HELM_BASE_URL = https://charts.upbound.io 
+HELM_BASE_URL = https://charts.upbound.io
 HELM_S3_BUCKET = public-upbound.charts
 HELM_CHARTS = xgql
 HELM_CHART_LINT_ARGS_xgql = --set nameOverride='',imagePullSecrets=''


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Removes a trailing space causing issues in CI when concatenating URL to branch.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Before:
```
🤖 (xgql-1) make -n helm.promote
echo `date +%H:%M:%S` [ .. ] promoting helm charts
aws s3 sync --only-show-errors s3://public-upbound.charts/master /tmp/tmp.QkzsL9avMr
if [ "public-upbound.releases/xgql" != "" ]; then \
	aws s3 sync --only-show-errors s3://public-upbound.releases/xgql/build/pub-bucket/v0.2.0-rc.0.48.gf01639a.dirty/charts /tmp/tmp.QkzsL9avMr; \
fi
/home/dan/code/github.com/upbound/xgql-1/.cache/tools/linux_x86_64/helm-v3.5.3 repo index --url https://charts.upbound.io /master /tmp/tmp.QkzsL9avMr
aws s3 sync --only-show-errors --delete /tmp/tmp.QkzsL9avMr s3://public-upbound.charts/master
aws s3 cp --only-show-errors --cache-control "private, max-age=0, no-transform" /tmp/tmp.QkzsL9avMr/index.yaml s3://public-upbound.charts/master/index.yaml
rm -fr /tmp/tmp.QkzsL9avMr
echo `date +%H:%M:%S` [ OK ] promoting helm charts
```

After:
```
🤖 (xgql-1) make -n helm.promote
echo `date +%H:%M:%S` [ .. ] promoting helm charts
aws s3 sync --only-show-errors s3://public-upbound.charts/master /tmp/tmp.doomB1IW3R
if [ "public-upbound.releases/xgql" != "" ]; then \
	aws s3 sync --only-show-errors s3://public-upbound.releases/xgql/build/whyyyy/v0.2.0-rc.0.49.g2898ba4.dirty/charts /tmp/tmp.doomB1IW3R; \
fi
/home/dan/code/github.com/upbound/xgql-1/.cache/tools/linux_x86_64/helm-v3.5.3 repo index --url https://charts.upbound.io/master /tmp/tmp.doomB1IW3R
aws s3 sync --only-show-errors --delete /tmp/tmp.doomB1IW3R s3://public-upbound.charts/master
aws s3 cp --only-show-errors --cache-control "private, max-age=0, no-transform" /tmp/tmp.doomB1IW3R/index.yaml s3://public-upbound.charts/master/index.yaml
rm -fr /tmp/tmp.doomB1IW3R
echo `date +%H:%M:%S` [ OK ] promoting helm charts
```