### PR TITLE
Add ability to filter defined resources by ready status.

### DIFF
--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -172,3 +172,39 @@ func GetComposition(cmp *extv1.Composition) Composition {
 		Unstructured: unstruct(cmp),
 	}
 }
+
+/* Handle deprecated items preferring non-deprecated */
+func (options *DefinedCompositeResourceOptionsInput) DeprecationPatch(version *string) {
+	if version != nil && options.Version == nil {
+		options.Version = version
+	}
+}
+
+/* Handle deprecated items preferring non-deprecated */
+func (options *DefinedCompositeResourceClaimOptionsInput) DeprecationPatch(version *string, namespace *string) {
+	if version != nil && options.Version == nil {
+		options.Version = version
+	}
+	if namespace != nil && options.Namespace == nil {
+		options.Namespace = namespace
+	}
+}
+
+/* A model that has conditions */
+type ConditionedModel interface {
+	GetConditions() []Condition
+}
+
+func (m *CompositeResourceClaim) GetConditions() []Condition {
+	if m.Status != nil {
+		return m.Status.Conditions
+	}
+	return nil
+}
+
+func (m *CompositeResource) GetConditions() []Condition {
+	if m.Status != nil {
+		return m.Status.Conditions
+	}
+	return nil
+}

--- a/internal/graph/model/apiextensions_test.go
+++ b/internal/graph/model/apiextensions_test.go
@@ -248,3 +248,150 @@ func TestGetComposition(t *testing.T) {
 		})
 	}
 }
+
+func TestDefinedCompositeResourceOptionsInputDeprecation(t *testing.T) {
+	version1 := "v1"
+	version2 := "v2"
+	type args struct {
+		options *DefinedCompositeResourceOptionsInput
+		version *string
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   *DefinedCompositeResourceOptionsInput
+	}{
+		"VersionNone": {
+			reason: "All supported fields should be converted to our model",
+			args: args{
+				options: &DefinedCompositeResourceOptionsInput{Version: nil},
+				version: nil,
+			},
+			want: &DefinedCompositeResourceOptionsInput{},
+		},
+		"VersionNonDeprecated": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options: &DefinedCompositeResourceOptionsInput{Version: &version1},
+				version: nil,
+			},
+			want: &DefinedCompositeResourceOptionsInput{Version: &version1},
+		},
+		"VersionDeprecated": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options: &DefinedCompositeResourceOptionsInput{Version: nil},
+				version: &version1,
+			},
+			want: &DefinedCompositeResourceOptionsInput{Version: &version1},
+		},
+		"VersionBoth": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options: &DefinedCompositeResourceOptionsInput{Version: &version1},
+				version: &version2,
+			},
+			want: &DefinedCompositeResourceOptionsInput{Version: &version1},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.args.options.DeprecationPatch(tc.args.version)
+			if diff := cmp.Diff(tc.want, tc.args.options); diff != "" {
+				t.Errorf("\n%s\nDeprecationPatch(...): -want, +got\n:%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestDefinedCompositeResourceClaimOptionsInputDeprecation(t *testing.T) {
+	version1 := "v1"
+	version2 := "v2"
+	namespace1 := "namespace1"
+	namespace2 := "namespace2"
+	type args struct {
+		options   *DefinedCompositeResourceClaimOptionsInput
+		version   *string
+		namespace *string
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   *DefinedCompositeResourceClaimOptionsInput
+	}{
+		"VersionNone": {
+			reason: "All supported fields should be converted to our model",
+			args: args{
+				options: &DefinedCompositeResourceClaimOptionsInput{Version: nil},
+				version: nil,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{},
+		},
+		"VersionNonDeprecated": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options: &DefinedCompositeResourceClaimOptionsInput{Version: &version1},
+				version: nil,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{Version: &version1},
+		},
+		"VersionDeprecated": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options: &DefinedCompositeResourceClaimOptionsInput{Version: nil},
+				version: &version1,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{Version: &version1},
+		},
+		"VersionBoth": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options: &DefinedCompositeResourceClaimOptionsInput{Version: &version1},
+				version: &version2,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{Version: &version1},
+		},
+		"NamespaceNone": {
+			reason: "All supported fields should be converted to our model",
+			args: args{
+				options:   &DefinedCompositeResourceClaimOptionsInput{Namespace: nil},
+				namespace: nil,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{},
+		},
+		"NamespaceNonDeprecated": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options:   &DefinedCompositeResourceClaimOptionsInput{Namespace: &namespace1},
+				namespace: nil,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{Namespace: &namespace1},
+		},
+		"NamespaceDeprecated": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options:   &DefinedCompositeResourceClaimOptionsInput{Namespace: nil},
+				namespace: &namespace1,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{Namespace: &namespace1},
+		},
+		"NamespaceBoth": {
+			reason: "Absent optional fields should be absent in our model",
+			args: args{
+				options:   &DefinedCompositeResourceClaimOptionsInput{Namespace: &namespace1},
+				namespace: &namespace2,
+			},
+			want: &DefinedCompositeResourceClaimOptionsInput{Namespace: &namespace1},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.args.options.DeprecationPatch(tc.args.version, tc.args.namespace)
+			if diff := cmp.Diff(tc.want, tc.args.options); diff != "" {
+				t.Errorf("\n%s\nDeprecationPatch(...): -want, +got\n:%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/graph/model/generated.go
+++ b/internal/graph/model/generated.go
@@ -608,6 +608,28 @@ type CustomResourceValidation struct {
 	OpenAPIV3Schema []byte `json:"openAPIV3Schema"`
 }
 
+// Options to filter or limit the defined composite claim resources
+type DefinedCompositeResourceClaimOptionsInput struct {
+	// Return resources of this version.
+	Version *string `json:"version"`
+	// Return resources in this namespace.
+	Namespace *string `json:"namespace"`
+	// Optionally limit the results to XRCs.
+	// If `true` return resources that have `Condition` `Ready` `True`.
+	// If `false` return resources that have `Condition` `Ready` `False` or `Condition` `Ready` not present
+	Ready *bool `json:"ready"`
+}
+
+// Options to filter or limit the defined composite resources
+type DefinedCompositeResourceOptionsInput struct {
+	// Return resources of this version.
+	Version *string `json:"version"`
+	// Optionally limit the results to XRCs.
+	// If `true` return resources that have `Condition` `Ready` `True`.
+	// If `false` return resources that have `Condition` `Ready` `False` or `Condition` `Ready` not present
+	Ready *bool `json:"ready"`
+}
+
 // DeleteKubernetesResourcePayload is the result of deleting a Kubernetes resource.
 type DeleteKubernetesResourcePayload struct {
 	// The deleted Kubernetes resource. Null if the delete failed.

--- a/schema/apiextensions.gql
+++ b/schema/apiextensions.gql
@@ -38,16 +38,60 @@ type CompositeResourceDefinition implements Node & KubernetesResource {
   definedCompositeResources(
     "Return resources of this version."
     version: String
+      @deprecated(
+        reason: "Use `DefinedCompositeResourceOptions`.version instead"
+      )
+
+    "Options to filter or limit the resources"
+    options: DefinedCompositeResourceOptionsInput
   ): CompositeResourceConnection! @goField(forceResolver: true)
 
   "Composite resource claims (XRCs) defined by this XRD."
   definedCompositeResourceClaims(
     "Return resources of this version."
     version: String
+      @deprecated(
+        reason: "Use `DefinedCompositeResourceClaimOptions`.version instead"
+      )
 
     "Return resources in this namespace."
     namespace: String
+      @deprecated(
+        reason: "Use `DefinedCompositeResourceClaimOptions`.namespace instead"
+      )
+
+    "Options to filter or limit the resources"
+    options: DefinedCompositeResourceClaimOptionsInput
   ): CompositeResourceClaimConnection! @goField(forceResolver: true)
+}
+
+"Options to filter or limit the defined composite resources"
+input DefinedCompositeResourceOptionsInput {
+  "Return resources of this version."
+  version: String
+
+  """
+  Optionally limit the results to XRCs.
+  If `true` return resources that have `Condition` `Ready` `True`.
+  If `false` return resources that have `Condition` `Ready` `False` or `Condition` `Ready` not present
+  """
+  ready: Boolean
+}
+
+"Options to filter or limit the defined composite claim resources"
+input DefinedCompositeResourceClaimOptionsInput {
+  "Return resources of this version."
+  version: String
+
+  "Return resources in this namespace."
+  namespace: String
+
+  """
+  Optionally limit the results to XRCs.
+  If `true` return resources that have `Condition` `Ready` `True`.
+  If `false` return resources that have `Condition` `Ready` `False` or `Condition` `Ready` not present
+  """
+  ready: Boolean
 }
 
 """


### PR DESCRIPTION
### Description of your changes

Add ability to filter defined resources by ready status.
This can be done for defined XRCs and XRs on an XRD.
This also deprecates the existing filters and moves them to an "options" input argument.

Resolves #94

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

ran `make` and `make reviewable`
