### PR TITLE
Introduce basic readyz and livez probes

### DIFF
--- a/cluster/charts/xgql/templates/deployment.yaml
+++ b/cluster/charts/xgql/templates/deployment.yaml
@@ -41,10 +41,22 @@ spec:
         name: {{ .Chart.Name }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
-        {{- if .Values.metrics.enabled }}
         ports:
+        {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: 8080
+        {{- end }}
+        {{- if .Values.health.enabled }}
+        - name: health
+          containerPort: 8088
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: health
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
         {{- end }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}

--- a/cluster/charts/xgql/values.yaml.tmpl
+++ b/cluster/charts/xgql/values.yaml.tmpl
@@ -38,3 +38,5 @@ securityContext:
 
 metrics:
   enabled: false
+health:
+  enabled: true

--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -218,9 +218,7 @@ func main() {
 	}
 
 	// start health endpoints to aid in routing traffic to the pod
-	if err := startHealth(internal.HealthOptions{Health: *health, HealthPort: *healthPort}, log); err != nil {
-		kingpin.FatalIfError(err, "cannot start health endpoints")
-	}
+	kingpin.FatalIfError(startHealth(internal.HealthOptions{Health: *health, HealthPort: *healthPort}, log), "cannot start health endpoints")
 
 	h := &http.Server{
 		Handler:           rt,
@@ -254,8 +252,7 @@ func startHealth(opts internal.HealthOptions, log logging.Logger) error {
 	go func() {
 		log.Debug("Listening for Health connections", "address", fmt.Sprintf(":%d", opts.HealthPort))
 		if err := p.ListenAndServe(); !errors.As(err, http.ErrServerClosed) {
-			err = errors.Wrap(err, "service stopped unexpectedly")
-			log.Info(err.Error())
+			log.Info(errors.Wrap(err, "service stopped unexpectedly").Error())
 			os.Exit(-1)
 		}
 	}()

--- a/internal/options.go
+++ b/internal/options.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// HealthOptions options related to readiness and liveness endpoints.
+type HealthOptions struct {
+	HealthPort int  `default:"8088" help:"Port for readiness and liveness server."`
+	Health     bool `name:"health" default:"true" negatable:"" help:"Enable readiness and liveness endpoints."`
+}

--- a/internal/request/formatter.go
+++ b/internal/request/formatter.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package request
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// Formatter provides a request logging formatter for incoming requests.
+type Formatter struct{ Log logging.Logger }
+
+// NewLogEntry emits a new log entry that includes request details.
+func (f *Formatter) NewLogEntry(r *http.Request) middleware.LogEntry {
+	return &entry{log: f.Log.WithValues(
+		"id", middleware.GetReqID(r.Context()),
+		"method", r.Method,
+		"tls", r.TLS != nil,
+		"host", r.Host,
+		"uri", r.RequestURI,
+		"protocol", r.Proto,
+		"remote", r.RemoteAddr,
+	)}
+}
+
+type entry struct{ log logging.Logger }
+
+func (e *entry) Write(status, bytes int, _ http.Header, elapsed time.Duration, _ interface{}) {
+	e.log.Debug("Handled request",
+		"status", status,
+		"bytes", bytes,
+		"duration", elapsed,
+	)
+}
+
+func (e *entry) Panic(v interface{}, stack []byte) {
+	e.log.Debug("Paniced while handling request", "stack", stack, "panic", v)
+}

--- a/internal/server/health/health.go
+++ b/internal/server/health/health.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"net/http"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+// GetLiveness gets the servic liveness.
+func (h *Probes) GetLiveness(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// GetReadiness gets the service readiness.
+func (h *Probes) GetReadiness(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// Probes indicates the health of a service.
+type Probes struct {
+	log logging.Logger
+}
+
+// Opt sets an option on the probes API.
+type Opt func(p *Probes)
+
+// WithLogger sets the logger for the probes API.
+func WithLogger(l logging.Logger) Opt {
+	return func(p *Probes) {
+		p.log = l
+	}
+}
+
+// New constructs a new probes API.
+func New(opts ...Opt) *Probes {
+	p := &Probes{
+		log: logging.NewNopLogger(),
+	}
+
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}

--- a/internal/server/health/server.go
+++ b/internal/server/health/server.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	chimid "github.com/go-chi/chi/v5/middleware"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+
+	"github.com/upbound/xgql/internal"
+	"github.com/upbound/xgql/internal/request"
+)
+
+// Server is a liveness and readiness server.
+func Server(opts internal.HealthOptions, log logging.Logger) (*http.Server, error) {
+	r := chi.NewRouter()
+	r.Use(chimid.RedirectSlashes)
+	r.Use(chimid.RequestLogger(&request.Formatter{Log: log}))
+	r.Use(chimid.Compress(5))
+
+	h := New(WithLogger(log))
+
+	r.Get("/livez", h.GetLiveness)
+	r.Get("/readyz", h.GetReadiness)
+
+	return &http.Server{
+		Handler:           r,
+		Addr:              fmt.Sprintf(":%d", opts.HealthPort),
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+	}, nil
+}


### PR DESCRIPTION
### Description of your changes
- adds handlers for livez and readyz
- extends current deployment.yaml to enable liveness and readiness probes

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Pushed local build to personal registry
2. Started a kind cluster
3. Updated values.yaml.tmpl to use the build docker image
4. Enabled debug logging within the deployment
5. `helm install xgql cluster/charts/xgql`
6. Verified the deployment recognized the liveness and readiness probes:
```
kubectl describe deploy xgql
Name:                   xgql
Namespace:              default
CreationTimestamp:      Wed, 14 Dec 2022 11:00:44 -0800
Labels:                 app=xgql
                        app.kubernetes.io/managed-by=Helm
                        chart=xgql-0.0.1
                        heritage=Helm
                        release=xgql
Annotations:            deployment.kubernetes.io/revision: 5
                        meta.helm.sh/release-name: xgql
                        meta.helm.sh/release-namespace: default
Selector:               app=xgql,release=xgql
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app=xgql
                    release=xgql
  Service Account:  xgql
  Containers:
   xgql:
    Image:      thorntontn/xgql-build:2
    Port:       8088/TCP
    Host Port:  0/TCP
    Args:
      --debug
    Limits:
      cpu:     100m
      memory:  512Mi
    Requests:
      cpu:      100m
      memory:   256Mi
    Liveness:   http-get http://:health/livez delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:  http-get http://:health/readyz delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      POD_NAMESPACE:   (v1:metadata.namespace)
    Mounts:           <none>
  Volumes:            <none>
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable
OldReplicaSets:  <none>
NewReplicaSet:   xgql-7948b5549 (1/1 replicas created)
Events:
  Type    Reason             Age    From                   Message
  ----    ------             ----   ----                   -------
  Normal  ScalingReplicaSet  17m    deployment-controller  Scaled up replica set xgql-69f5669769 to 1
  Normal  ScalingReplicaSet  14m    deployment-controller  Scaled up replica set xgql-6d8d9fb896 to 1
  Normal  ScalingReplicaSet  14m    deployment-controller  Scaled down replica set xgql-69f5669769 to 0 from 1
  Normal  ScalingReplicaSet  12m    deployment-controller  Scaled up replica set xgql-556d9dc7c8 to 1
  Normal  ScalingReplicaSet  12m    deployment-controller  Scaled down replica set xgql-6d8d9fb896 to 0 from 1
  Normal  ScalingReplicaSet  3m23s  deployment-controller  Scaled up replica set xgql-57cc57869f to 1
  Normal  ScalingReplicaSet  3m13s  deployment-controller  Scaled down replica set xgql-556d9dc7c8 to 0 from 1
  Normal  ScalingReplicaSet  2m46s  deployment-controller  Scaled up replica set xgql-7948b5549 to 1
  Normal  ScalingReplicaSet  2m36s  deployment-controller  Scaled down replica set xgql-57cc57869f to 0 from 1
```
7. Checked the logs for the pod and verified the handlers were being called:
```
kubectl logs -f xgql-7948b5549-xxtql
2022-12-14T19:15:39.268Z	DEBUG	xgql	Listening for insecure connections	{"address": "127.0.0.1:8080"}
2022-12-14T19:15:39.268Z	DEBUG	xgql	Listening for Health connections	{"address": ":8088"}
2022-12-14T19:15:45.894Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "10.244.0.1:33770", "status": 200, "bytes": 0, "duration": "8.167µs"}
2022-12-14T19:15:45.894Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/livez", "protocol": "HTTP/1.1", "remote": "10.244.0.1:33768", "status": 200, "bytes": 0, "duration": "30.166µs"}
2022-12-14T19:15:55.897Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/livez", "protocol": "HTTP/1.1", "remote": "10.244.0.1:59912", "status": 200, "bytes": 0, "duration": "191.208µs"}
2022-12-14T19:15:55.897Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "10.244.0.1:59914", "status": 200, "bytes": 0, "duration": "191.167µs"}
2022-12-14T19:16:05.895Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/livez", "protocol": "HTTP/1.1", "remote": "10.244.0.1:58506", "status": 200, "bytes": 0, "duration": "46.333µs"}
2022-12-14T19:16:05.896Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "10.244.0.1:58504", "status": 200, "bytes": 0, "duration": "14.25µs"}
2022-12-14T19:16:15.894Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/livez", "protocol": "HTTP/1.1", "remote": "10.244.0.1:43360", "status": 200, "bytes": 0, "duration": "72.833µs"}
2022-12-14T19:16:15.894Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "10.244.0.1:43362", "status": 200, "bytes": 0, "duration": "82.041µs"}
2022-12-14T19:16:25.895Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/livez", "protocol": "HTTP/1.1", "remote": "10.244.0.1:60522", "status": 200, "bytes": 0, "duration": "43.459µs"}
2022-12-14T19:16:25.895Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "10.244.0.1:60514", "status": 200, "bytes": 0, "duration": "13.583µs"}
2022-12-14T19:16:35.892Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/livez", "protocol": "HTTP/1.1", "remote": "10.244.0.1:49554", "status": 200, "bytes": 0, "duration": "16.125µs"}
2022-12-14T19:16:35.892Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "10.244.0.1:49556", "status": 200, "bytes": 0, "duration": "4.917µs"}
2022-12-14T19:16:45.892Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/livez", "protocol": "HTTP/1.1", "remote": "10.244.0.1:36618", "status": 200, "bytes": 0, "duration": "36.625µs"}
2022-12-14T19:16:45.892Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "10.244.0.9:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "10.244.0.1:36620", "status": 200, "bytes": 0, "duration": "36.625µs"}
```
