### PR TITLE
Extend error presentation to account for other error types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ GO111MODULE = on
 -include build/makelib/yarnjs.mk
 
 # Setup Helm
+KIND_VERSION = v0.16.0
 USE_HELM3 = true
 HELM_BASE_URL = https://charts.upbound.io
 HELM_S3_BUCKET = public-upbound.charts

--- a/internal/graph/present/present.go
+++ b/internal/graph/present/present.go
@@ -16,12 +16,15 @@ package present
 
 import (
 	"context"
+	"syscall"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
 const (
@@ -38,6 +41,21 @@ const (
 
 	// Code is the error code, if any.
 	Code = "code"
+
+	// Type is the error type, if any.
+	Type = "type"
+)
+
+// An ErrorCode indicates the type of error.
+type ErrorCode string
+
+const (
+	// ErrorNotFound is an error class that indicates to the caller that the
+	// item that was queried was not found.
+	ErrorNotFound ErrorCode = "NOT_FOUND_ERROR"
+	// ErrorRetryable is an error class that indicates to the caller that they
+	// are safe to retry the operation.
+	ErrorRetryable ErrorCode = "RETRYABLE_ERROR"
 )
 
 // An ErrorSource indicates where an error originated.
@@ -45,9 +63,23 @@ type ErrorSource string
 
 // Error sources.
 const (
-	ErrorSourceUnknown   ErrorSource = "Unknown"
+	ErrorSourceAPI       ErrorSource = "API"
 	ErrorSourceAPIServer ErrorSource = "APIServer"
+	ErrorSourceCache     ErrorSource = "Cache"
+	ErrorSourceNetwork   ErrorSource = "Network"
+	ErrorSourceUnknown   ErrorSource = "Unknown"
 )
+
+type serverError struct {
+	Code   ErrorCode
+	Reason string
+	Source ErrorSource
+	Type   string
+}
+
+func (r *serverError) Error() string {
+	return r.Reason
+}
 
 // wrap adds context to a *gqlerror.Error message while maintaining metadata
 // such as its ast.Path that would be obfuscated by errors.Wrap.
@@ -59,6 +91,55 @@ func wrap(err error, message string) error {
 
 	gerr.Message = message + ": " + gerr.Message
 	return gerr
+}
+
+// convert the provided error to a serverError or return the original error
+// if the provided error didn't match the expected types.
+func convert(err error) error {
+	// Errors due to transient failures.
+	var cache *cache.ErrCacheNotStarted
+	var dead = context.DeadlineExceeded
+	var ref = syscall.ECONNREFUSED
+
+	// Errors indicating that the query failed due to a non-existent failure.
+	var kind *meta.NoKindMatchError
+	var res *meta.NoResourceMatchError
+
+	// APIStatus errors.
+	s := kerrors.APIStatus(nil)
+
+	switch {
+	case errors.As(err, &s):
+		return err
+	case errors.As(err, &kind):
+		return &serverError{
+			Source: ErrorSourceAPI,
+			Reason: err.Error(),
+			Code:   ErrorNotFound,
+			Type:   "NoMatchKind",
+		}
+	case errors.As(err, &res):
+		return &serverError{
+			Source: ErrorSourceAPI,
+			Reason: err.Error(),
+			Code:   ErrorNotFound,
+			Type:   "NoMatchResource",
+		}
+	case errors.As(err, &cache):
+		return &serverError{
+			Source: ErrorSourceCache,
+			Reason: err.Error(),
+			Code:   ErrorRetryable,
+		}
+	case errors.As(err, &dead), errors.As(err, &ref):
+		return &serverError{
+			Source: ErrorSourceNetwork,
+			Reason: err.Error(),
+			Code:   ErrorRetryable,
+		}
+	default:
+		return err
+	}
 }
 
 // Extend an error with GraphQL extensions.
@@ -80,28 +161,37 @@ func Extend(ctx context.Context, err error, ext map[string]interface{}) *gqlerro
 // Error 'presents' errors encountered by GraphQL resolvers.
 func Error(ctx context.Context, err error) *gqlerror.Error {
 	s := kerrors.APIStatus(nil)
+	var e *serverError
 
-	// This does not appear to be an error from the API server.
-	if !errors.As(err, &s) {
-		return Extend(ctx, err, map[string]interface{}{Source: ErrorSourceUnknown})
+	// convert the error if applicable
+	cerr := convert(err)
+
+	switch {
+	case errors.As(cerr, &e):
+		return Extend(ctx, cerr, map[string]interface{}{
+			Source: e.Source,
+			Code:   e.Code,
+			Type:   e.Type,
+		})
+	case errors.As(cerr, &s):
+		// Most xgql resolvers read from a controller-runtime cache that is hydrated
+		// by taking a watch on any type they're asked to read. The cache uses the
+		// credentials passed in by the caller, and will never start if those
+		// credentials can't take a watch on the desired type for some reason. If
+		// the cache hasn't started by the time the resolver's context is cancelled
+		// it will return a timeout error with an obtuse message about an "informer
+		// failing to sync". The most common reason a cache won't start is because
+		// the caller doesn't have RBAC permissions to list or watch the desired
+		// type, so we wrap the error with a hint.
+		if s.Status().Reason == metav1.StatusReasonTimeout {
+			cerr = wrap(cerr, errRBAC)
+		}
+		return Extend(ctx, cerr, map[string]interface{}{
+			Source: ErrorSourceAPIServer,
+			Reason: s.Status().Reason,
+			Code:   s.Status().Code,
+		})
+	default:
+		return Extend(ctx, cerr, map[string]interface{}{Source: ErrorSourceUnknown})
 	}
-
-	// Most xgql resolvers read from a controller-runtime cache that is hydrated
-	// by taking a watch on any type they're asked to read. The cache uses the
-	// credentials passed in by the caller, and will never start if those
-	// credentials can't take a watch on the desired type for some reason. If
-	// the cache hasn't started by the time the resolver's context is cancelled
-	// it will return a timeout error with an obtuse message about an "informer
-	// failing to sync". The most common reason a cache won't start is because
-	// the caller doesn't have RBAC permissions to list or watch the desired
-	// type, so we wrap the error with a hint.
-	if s.Status().Reason == metav1.StatusReasonTimeout {
-		err = wrap(err, errRBAC)
-	}
-
-	return Extend(ctx, err, map[string]interface{}{
-		Source: ErrorSourceAPIServer,
-		Reason: s.Status().Reason,
-		Code:   s.Status().Code,
-	})
 }

--- a/internal/graph/present/present_test.go
+++ b/internal/graph/present/present_test.go
@@ -16,22 +16,29 @@ package present
 
 import (
 	"context"
+	"errors"
+	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
 func TestError(t *testing.T) {
 	errTimeout := kerrors.NewTimeoutError("too slow", 0)
+	errNetwork := syscall.ECONNREFUSED
+	errNoKindMatch := &meta.NoKindMatchError{}
 	errBoom := errors.New("boom")
 
 	gerrTimeout := gqlerror.WrapPath(nil, errTimeout)
+	gerrNetwork := gqlerror.WrapPath(nil, errNetwork)
+	gerrNoKindMatch := gqlerror.WrapPath(nil, errNoKindMatch)
 	gerrBoom := gqlerror.WrapPath(nil, errBoom)
+	gqlInput := "input: "
 
 	type args struct {
 		ctx context.Context
@@ -53,13 +60,35 @@ func TestError(t *testing.T) {
 				Message: errRBAC + ": " + gerrTimeout.Message,
 			},
 		},
+		"NetworkError": {
+			reason: "Network related errors should be 'upgraded' to a GQL error. ",
+			args: args{
+				ctx: context.Background(),
+				err: gerrNetwork,
+			},
+			want: &gqlerror.Error{
+				Message: gqlInput + gerrNetwork.Message,
+			},
+		},
+		"NotFoundError": {
+			reason: "Error types classified as 'Not Found' should be 'upgraded' to a GQL error. ",
+			args: args{
+				ctx: context.Background(),
+				err: gerrNoKindMatch,
+			},
+			want: &gqlerror.Error{
+				Message: gqlInput + gerrNoKindMatch.Message,
+			},
+		},
 		"OtherGQLError": {
 			reason: "Regular GQL errors should be returned unchanged.",
 			args: args{
 				ctx: context.Background(),
 				err: gerrBoom,
 			},
-			want: gerrBoom,
+			want: &gqlerror.Error{
+				Message: gqlInput + gerrBoom.Message,
+			},
 		},
 		"OtherTimeoutError": {
 			reason: "Non-GQL timeout errors should be both decorated and 'upgraded' to a GQL error.",


### PR DESCRIPTION
### Description of your changes
Prior to this change, client calls would typically see a number of error messages that could be gracefully handled by the client if they included additional context.
For example:
- non APIStatus timeouts 
- non APIStatus connection resets when communicating with the API server
- queries that would generally return a NoMatchKind or NoMatchResource
each of these errors would return a source `Unknown`.

This changeset:
- introduce new NOT_FOUND_ERROR  code
- introduce new RETRYABLE_ERROR code
- represent NoMatchKind and NoMatchResource differently so clients can distinguish between the two

Clients are now able to:
- distinguish INTERNAL_SERVER_ERROR from NOT_FOUND_ERRORs
- be signaled that the error they received is retryable when receiving the RETRYABLE_ERROR code.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
New unit tests.

Manual tests involved:
- Initiating queries for a `ProviderConfig` that did not yet exist and verifying that NOT_FOUND_ERROR was returned.
- Querying xgql while in a 2 pod deployment while:
   - rolling restarting the deployment and querying for various resources and verifying that RETRYABLE_ERROR was returned.
   - restarting the api-server and querying for various resources and verifying that RETRYABLE_ERROR was returned.
