### PR TITLE
Handle cases where CompositeResource.ResourceReferences has entries with no name

### DIFF
--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -195,6 +195,11 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 	}
 
 	for _, ref := range obj.ResourceReferences {
+		// Ignore nameless resource references
+		if ref.Name == "" {
+			continue
+		}
+
 		xrc := &unstructured.Unstructured{}
 		xrc.SetAPIVersion(ref.APIVersion)
 		xrc.SetKind(ref.Kind)
@@ -213,6 +218,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 		out.Nodes = append(out.Nodes, kr)
 		out.TotalCount++
 	}
+	out.Nodes = out.Nodes[:out.TotalCount]
 
 	sort.Stable(out)
 	return out, nil


### PR DESCRIPTION
### Description of your changes

Handle cases where CompositeResource.ResourceReferences has entries with no name by ignoring them.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Verified locally and with unit tests that when CompositeResource.ResourceReferences contained entries with no name (i.e. name == "") we just ignore that ref.
