### PR TITLE
Move to using unstructured.Unstructured rather than extv1.CustomResourceDefinition

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -91,6 +91,7 @@ var noCache = []client.Object{
 	&appsv1.DaemonSet{},
 	&rbacv1.RoleBinding{},
 	&rbacv1.ClusterRoleBinding{},
+	&kextv1.CustomResourceDefinition{},
 
 	// We don't cache secrets because there's a high risk that the caller won't
 	// have access to list and watch secrets across all namespaces.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/epk/smaz v0.0.0-20220720222521-c11a89997fcf
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-chi/chi/v5 v5.0.3
+	github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929
 	github.com/google/addlicense v0.0.0-20210428195630-6d92264d7170
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
@@ -90,6 +91,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
+	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/go-chi/chi/v5 v5.0.3/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITL
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929 h1:GdbUZo0+623j+pKRhwwdf1q28IUgRc7asx3TjF9b7VQ=
+github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929/go.mod h1:AHV+bpNGVGD0DCHMBhhTYtT7yeBYD9Yk92XAjB7vOgo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -820,6 +822,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -15,8 +15,9 @@
 package model
 
 import (
+	"encoding/json"
+
 	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/google/go-cmp/cmp"
 

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -75,7 +75,7 @@ func GetCompositeResource(u *kunstructured.Unstructured) CompositeResource {
 			WriteConnectionSecretToReference: xr.GetWriteConnectionSecretToReference(),
 		},
 		Status:       GetCompositeResourceStatus(xr),
-		Unstructured: unstruct(xr),
+		Unstructured: bytesForUnstructured(u),
 	}
 }
 
@@ -141,6 +141,6 @@ func GetCompositeResourceClaim(u *kunstructured.Unstructured) CompositeResourceC
 			WriteConnectionSecretToReference: delocalize(xrc.GetWriteConnectionSecretToReference(), xrc.GetNamespace()),
 		},
 		Status:       GetCompositeResourceClaimStatus(xrc),
-		Unstructured: unstruct(xrc),
+		Unstructured: bytesForUnstructured(u),
 	}
 }

--- a/internal/graph/model/managed.go
+++ b/internal/graph/model/managed.go
@@ -80,6 +80,6 @@ func GetManagedResource(u *kunstructured.Unstructured) ManagedResource {
 			DeletionPolicy:                   GetDeletionPolicy(mg.GetDeletionPolicy()),
 		},
 		Status:       GetManagedResourceStatus(mg),
-		Unstructured: unstruct(mg),
+		Unstructured: bytesForUnstructured(u),
 	}
 }

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -51,6 +51,6 @@ func GetProviderConfig(u *kunstructured.Unstructured) ProviderConfig {
 		Kind:         pc.GetKind(),
 		Metadata:     GetObjectMeta(pc),
 		Status:       GetProviderConfigStatus(pc),
-		Unstructured: unstruct(pc),
+		Unstructured: bytesForUnstructured(u),
 	}
 }

--- a/internal/graph/model/util.go
+++ b/internal/graph/model/util.go
@@ -15,11 +15,12 @@
 package model
 
 import (
+	"github.com/go-json-experiment/json"
+
 	"github.com/pkg/errors"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/json"
 )
 
 // unstruct returns the supplied object as unstructured JSON bytes. It panics if
@@ -27,6 +28,17 @@ import (
 // program is fundamentally broken - e.g. trying to use a weird runtime.Object.
 func unstruct(obj runtime.Object) []byte {
 	out, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+// bytesForUnstructured returns the supplied unstructured.Unstructured as JSON
+// bytes. It panics if the object cannot be marshalled as JSON, which _should_
+// only happen if this program is fundamentally broken.
+func bytesForUnstructured(u *kunstructured.Unstructured) []byte {
+	out, err := json.Marshal(u.Object)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -22,7 +22,6 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,6 +32,7 @@ import (
 	"github.com/upbound/xgql/internal/auth"
 	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/model"
+	"github.com/upbound/xgql/internal/unstructured"
 )
 
 const (
@@ -66,7 +66,9 @@ func (r *xrd) getCrd(ctx context.Context, group string, names *model.CompositeRe
 	}
 
 	nn := types.NamespacedName{Name: fmt.Sprintf("%s.%s", names.Plural, group)}
-	in := &kextv1.CustomResourceDefinition{}
+	in := &unstructured.CustomResourceDefinition{}
+	in.SetAPIVersion("apiextensions.k8s.io/v1")
+	in.SetKind("CustomResourceDefinition")
 	if err := c.Get(ctx, nn, in); err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
 		return nil, nil

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -140,9 +140,11 @@ func TestCompositeResourceCrd(t *testing.T) {
 			},
 			want: want{
 				crd: &model.CustomResourceDefinition{
-					ID:       model.ReferenceID{Name: "some.crd"},
-					Metadata: &model.ObjectMeta{Name: "some.crd"},
-					Spec:     &model.CustomResourceDefinitionSpec{Names: &model.CustomResourceDefinitionNames{}},
+					APIVersion: crdAPIVersion,
+					Kind:       crdKind,
+					ID:         model.ReferenceID{Name: "some.crd", APIVersion: crdAPIVersion, Kind: crdKind},
+					Metadata:   &model.ObjectMeta{Name: "some.crd"},
+					Spec:       &model.CustomResourceDefinitionSpec{Names: &model.CustomResourceDefinitionNames{}, Versions: []model.CustomResourceDefinitionVersion{}},
 				},
 			},
 		},
@@ -264,9 +266,11 @@ func TestCompositeResourceClaimCrd(t *testing.T) {
 			},
 			want: want{
 				crd: &model.CustomResourceDefinition{
-					ID:       model.ReferenceID{Name: "some.crd"},
-					Metadata: &model.ObjectMeta{Name: "some.crd"},
-					Spec:     &model.CustomResourceDefinitionSpec{Names: &model.CustomResourceDefinitionNames{}},
+					APIVersion: crdAPIVersion,
+					Kind:       crdKind,
+					ID:         model.ReferenceID{Name: "some.crd", APIVersion: crdAPIVersion, Kind: crdKind},
+					Metadata:   &model.ObjectMeta{Name: "some.crd"},
+					Spec:       &model.CustomResourceDefinitionSpec{Names: &model.CustomResourceDefinitionNames{}, Versions: []model.CustomResourceDefinitionVersion{}},
 				},
 			},
 		},
@@ -773,7 +777,10 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResources(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crc, got,
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"),
+			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResources(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1447,7 +1454,10 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crcc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crcc, got,
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"),
+			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/common_test.go
+++ b/internal/graph/resolvers/common_test.go
@@ -41,6 +41,9 @@ var (
 	_ generated.SecretResolver                   = &secret{}
 	_ generated.ConfigMapResolver                = &configMap{}
 	_ generated.CustomResourceDefinitionResolver = &crd{}
+
+	crdAPIVersion = "apiextensions.k8s.io/v1"
+	crdKind       = "CustomResourceDefinition"
 )
 
 func TestCRDDefinedResources(t *testing.T) {

--- a/internal/graph/resolvers/managed.go
+++ b/internal/graph/resolvers/managed.go
@@ -74,13 +74,6 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 	name := pluralForm(strings.ToLower(obj.Kind))
 
 	nn := types.NamespacedName{Name: fmt.Sprintf("%s.%s", name, gv.Group)}
-	// in := &unstructured.CustomResourceDefinition{}
-	// xrc.SetAPIVersion(obj.ClaimReference.APIVersion)
-	// xrc.SetKind(obj.ClaimReference.Kind)
-	// apiVersion: apiextensions.k8s.io/v1
-	// kind: CustomResourceDefinition
-	// in.SetAPIVersion(crdAPIVersion)
-	// in.SetKind(crdKind)
 	in := unstructured.NewCRD()
 	err = c.Get(ctx, nn, in)
 
@@ -92,9 +85,6 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 	// We didn't find the CRD we were looking for, list all CRDs and see if we
 	// can find the matching one.
 	if kerrors.IsNotFound(err) {
-		// lin := &kunstructured.UnstructuredList{}
-		// lin.SetAPIVersion(crdAPIVersion)
-		// lin.SetKind(crdKindList)
 		lin := unstructured.NewCRDList()
 		if err := c.List(ctx, lin); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errListCRDs))

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -27,6 +27,7 @@ import (
 	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -36,6 +37,7 @@ import (
 	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/generated"
 	"github.com/upbound/xgql/internal/graph/model"
+	"github.com/upbound/xgql/internal/unstructured"
 )
 
 var _ generated.ManagedResourceSpecResolver = &managedResourceSpec{}
@@ -48,34 +50,24 @@ func TestManagedResourceDefinition(t *testing.T) {
 		},
 	}
 
-	crd := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.org",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Example"},
-		},
-	}
-	crdDifferingPlural := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.org",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"},
-		},
-	}
-	gcrd := model.GetCustomResourceDefinition(&crd)
-	dcrd := model.GetCustomResourceDefinition((&crdDifferingPlural))
+	crd := unstructured.NewCRD()
+	crd.SetSpecGroup("example.org")
+	crd.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example"})
 
-	otherGroup := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.net",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Example"},
-		},
-	}
+	crdDifferingPlural := unstructured.NewCRD()
+	crdDifferingPlural.SetSpecGroup("example.org")
+	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	otherKind := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.org",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Illustration"},
-		},
-	}
+	gcrd := model.GetCustomResourceDefinition(crd)
+	dcrd := model.GetCustomResourceDefinition((crdDifferingPlural))
+
+	otherGroup := unstructured.NewCRD()
+	otherGroup.SetSpecGroup("example.net")
+	otherGroup.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example"})
+
+	otherKind := unstructured.NewCRD()
+	otherKind.SetSpecGroup("example.org")
+	otherKind.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Illustration"})
 
 	type args struct {
 		ctx context.Context
@@ -150,7 +142,7 @@ func TestManagedResourceDefinition(t *testing.T) {
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						*obj.(*kextv1.CustomResourceDefinition) = crd
+						*obj.(*unstructured.CustomResourceDefinition) = *crd
 						return nil
 					}),
 				}, nil
@@ -158,8 +150,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 			args: args{
 				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.ManagedResource{
-					APIVersion: crd.Spec.Group + "/v1",
-					Kind:       crd.Spec.Names.Kind,
+					APIVersion: crd.GetSpecGroup() + "/v1",
+					Kind:       crd.GetSpecNames().Kind,
 				},
 			},
 			want: want{
@@ -167,8 +159,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 			},
 		},
 		"DifferentPlural": {
-			reason: `In the event we get a request for an object whose CRD has 
-			a non-predictable plural form, ensure the CRD list contains the 
+			reason: `In the event we get a request for an object whose CRD has
+			a non-predictable plural form, ensure the CRD list contains the
 			expected resource.`,
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
@@ -176,8 +168,10 @@ func TestManagedResourceDefinition(t *testing.T) {
 						return errNotFound
 					}),
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*kextv1.CustomResourceDefinitionList) = kextv1.CustomResourceDefinitionList{
-							Items: []kextv1.CustomResourceDefinition{otherGroup, otherKind, crdDifferingPlural},
+						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
+							UnstructuredList: kunstructured.UnstructuredList{
+								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured, crdDifferingPlural.Unstructured},
+							},
 						}
 						return nil
 					}),
@@ -186,8 +180,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 			args: args{
 				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.ManagedResource{
-					APIVersion: crd.Spec.Group + "/v1",
-					Kind:       crd.Spec.Names.Kind,
+					APIVersion: crdDifferingPlural.GetSpecGroup() + "/v1",
+					Kind:       crdDifferingPlural.GetSpecNames().Kind,
 				},
 			},
 			want: want{
@@ -202,8 +196,10 @@ func TestManagedResourceDefinition(t *testing.T) {
 						return errNotFound
 					}),
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*kextv1.CustomResourceDefinitionList) = kextv1.CustomResourceDefinitionList{
-							Items: []kextv1.CustomResourceDefinition{otherGroup, otherKind},
+						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
+							UnstructuredList: kunstructured.UnstructuredList{
+								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured},
+							},
 						}
 						return nil
 					}),
@@ -212,8 +208,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 			args: args{
 				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.ManagedResource{
-					APIVersion: crd.Spec.Group + "/v1",
-					Kind:       crd.Spec.Names.Kind,
+					APIVersion: crd.GetSpecGroup() + "/v1",
+					Kind:       crd.GetSpecNames().Kind,
 				},
 			},
 			want: want{
@@ -237,7 +233,10 @@ func TestManagedResourceDefinition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.mrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.mrd, got,
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
+			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/mutation.go
+++ b/internal/graph/resolvers/mutation.go
@@ -16,13 +16,13 @@ package resolvers
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"

--- a/internal/graph/resolvers/mutation_test.go
+++ b/internal/graph/resolvers/mutation_test.go
@@ -16,6 +16,7 @@ package resolvers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -27,7 +28,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
@@ -89,7 +89,7 @@ func TestIsRetriable(t *testing.T) {
 func TestCreateKubernetesResource(t *testing.T) {
 	errBoom := errors.New("boom")
 	errFieldPath := fieldpath.Pave(map[string]interface{}{}).SetValue("..", nil)
-	errUnmarshal := json.Unmarshal([]byte("\""), nil)
+	errUnmarshal := json.Unmarshal([]byte("\""), nil) //nolint:govet
 
 	// Unmarshalling to an *interface{} results in a slightly different error.
 	var v interface{}
@@ -256,7 +256,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 func TestUpdateKubernetesResource(t *testing.T) {
 	errBoom := errors.New("boom")
 	errFieldPath := fieldpath.Pave(map[string]interface{}{}).SetValue("..", nil)
-	errUnmarshal := json.Unmarshal([]byte("\""), nil)
+	errUnmarshal := json.Unmarshal([]byte("\""), nil) //nolint:govet
 
 	// Unmarshalling to an *interface{} results in a slightly different error.
 	var v interface{}

--- a/internal/graph/resolvers/objectmeta_test.go
+++ b/internal/graph/resolvers/objectmeta_test.go
@@ -139,7 +139,10 @@ func TestObjectMetaOwners(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Owners(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.oc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.oc, got,
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
+			); diff != "" {
 				t.Errorf("\n%s\nq.Owners(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -281,7 +284,10 @@ func TestObjectMetaController(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Controller(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got,
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
+			); diff != "" {
 				t.Errorf("\n%s\nq.Controller(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -174,9 +174,6 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 			continue
 		}
 
-		// crd := &unstructured.CustomResourceDefinition{}
-		// crd.SetAPIVersion(crdAPIVersion)
-		// crd.SetKind(crdKind)
 		crd := unstructured.NewCRD()
 		if err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, crd); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errGetCRD))

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/upbound/xgql/internal/auth"
 	"github.com/upbound/xgql/internal/graph/model"
+	"github.com/upbound/xgql/internal/unstructured"
 )
 
 const (
@@ -173,7 +174,10 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 			continue
 		}
 
-		crd := &kextv1.CustomResourceDefinition{}
+		// crd := &unstructured.CustomResourceDefinition{}
+		// crd.SetAPIVersion(crdAPIVersion)
+		// crd.SetKind(crdKind)
+		crd := unstructured.NewCRD()
 		if err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, crd); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
 			continue

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/generated"
 	"github.com/upbound/xgql/internal/graph/model"
+	"github.com/upbound/xgql/internal/unstructured"
 )
 
 var (
@@ -316,7 +317,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinition(&kextv1.CustomResourceDefinition{})
+	gcrd := model.GetCustomResourceDefinition(&unstructured.CustomResourceDefinition{})
 
 	type args struct {
 		ctx context.Context
@@ -444,7 +445,10 @@ func TestProviderRevisionStatusObjects(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got,
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
+			); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/providerconfig.go
+++ b/internal/graph/resolvers/providerconfig.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +29,7 @@ import (
 
 	"github.com/upbound/xgql/internal/auth"
 	"github.com/upbound/xgql/internal/graph/model"
+	"github.com/upbound/xgql/internal/unstructured"
 )
 
 type providerConfig struct {
@@ -73,7 +73,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 
 	nn := types.NamespacedName{Name: fmt.Sprintf("%s.%s", name, gv.Group)}
 
-	in := &kextv1.CustomResourceDefinition{}
+	in := unstructured.NewCRD()
 	err = c.Get(ctx, nn, in)
 
 	if err != nil && !kerrors.IsNotFound(err) {
@@ -84,20 +84,20 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 	// We didn't find the CRD we were looking for, list all CRDs and see if we
 	// can find the matching one.
 	if kerrors.IsNotFound(err) {
-		lin := &kextv1.CustomResourceDefinitionList{}
+		lin := unstructured.NewCRDList()
 		if err := c.List(ctx, lin); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errListCRDs))
 			return nil, nil
 		}
 
 		for i := range lin.Items {
-			crd := lin.Items[i] // So we don't take the address of a range variable.
+			crd := unstructured.CustomResourceDefinition{Unstructured: lin.Items[i]} // So we don't take the address of a range variable.
 
-			if crd.Spec.Group != gv.Group {
+			if crd.GetSpecGroup() != gv.Group {
 				continue
 			}
 
-			if crd.Spec.Names.Kind != obj.Kind {
+			if crd.GetSpecNames().Kind != obj.Kind {
 				continue
 			}
 
@@ -108,7 +108,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 
 	// We found a CRD, let's double check the Group and Kind match our
 	// expectations.
-	if in.Spec.Group == gv.Group && in.Spec.Names.Kind == obj.Kind {
+	if in.GetSpecGroup() == gv.Group && in.GetSpecNames().Kind == obj.Kind {
 		out := model.GetCustomResourceDefinition(in)
 		return &out, nil
 	}

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -26,6 +26,7 @@ import (
 	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -34,6 +35,7 @@ import (
 	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/generated"
 	"github.com/upbound/xgql/internal/graph/model"
+	"github.com/upbound/xgql/internal/unstructured"
 )
 
 var _ generated.ProviderConfigResolver = &providerConfig{}
@@ -46,34 +48,24 @@ func TestProviderConfigDefinition(t *testing.T) {
 		},
 	}
 
-	crd := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.org",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Example"},
-		},
-	}
-	crdDifferingPlural := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.org",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"},
-		},
-	}
-	gcrd := model.GetCustomResourceDefinition(&crd)
-	dcrd := model.GetCustomResourceDefinition((&crdDifferingPlural))
+	crd := unstructured.NewCRD()
+	crd.SetSpecGroup("example.org")
+	crd.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example"})
 
-	otherGroup := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.net",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Example"},
-		},
-	}
+	crdDifferingPlural := unstructured.NewCRD()
+	crdDifferingPlural.SetSpecGroup("example.org")
+	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	otherKind := kextv1.CustomResourceDefinition{
-		Spec: kextv1.CustomResourceDefinitionSpec{
-			Group: "example.org",
-			Names: kextv1.CustomResourceDefinitionNames{Kind: "Illustration"},
-		},
-	}
+	gcrd := model.GetCustomResourceDefinition(crd)
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural)
+
+	otherGroup := unstructured.NewCRD()
+	otherGroup.SetSpecGroup("example.net")
+	otherGroup.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example"})
+
+	otherKind := unstructured.NewCRD()
+	otherKind.SetSpecGroup("example.org")
+	otherKind.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Illustration"})
 
 	type args struct {
 		ctx context.Context
@@ -148,7 +140,7 @@ func TestProviderConfigDefinition(t *testing.T) {
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						*obj.(*kextv1.CustomResourceDefinition) = crd
+						*obj.(*unstructured.CustomResourceDefinition) = *crd
 						return nil
 					}),
 				}, nil
@@ -156,8 +148,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 			args: args{
 				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.ProviderConfig{
-					APIVersion: crd.Spec.Group + "/v1",
-					Kind:       crd.Spec.Names.Kind,
+					APIVersion: crd.GetSpecGroup() + "/v1",
+					Kind:       crd.GetSpecNames().Kind,
 				},
 			},
 			want: want{
@@ -174,8 +166,10 @@ func TestProviderConfigDefinition(t *testing.T) {
 						return errNotFound
 					}),
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*kextv1.CustomResourceDefinitionList) = kextv1.CustomResourceDefinitionList{
-							Items: []kextv1.CustomResourceDefinition{otherGroup, otherKind, crdDifferingPlural},
+						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
+							UnstructuredList: kunstructured.UnstructuredList{
+								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured, crdDifferingPlural.Unstructured},
+							},
 						}
 						return nil
 					}),
@@ -184,8 +178,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 			args: args{
 				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.ProviderConfig{
-					APIVersion: crd.Spec.Group + "/v1",
-					Kind:       crd.Spec.Names.Kind,
+					APIVersion: crd.GetSpecGroup() + "/v1",
+					Kind:       crd.GetSpecNames().Kind,
 				},
 			},
 			want: want{
@@ -197,7 +191,14 @@ func TestProviderConfigDefinition(t *testing.T) {
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						*obj.(*kextv1.CustomResourceDefinition) = otherGroup
+						return errNotFound
+					}),
+					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
+						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
+							UnstructuredList: kunstructured.UnstructuredList{
+								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured},
+							},
+						}
 						return nil
 					}),
 				}, nil
@@ -205,8 +206,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 			args: args{
 				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.ProviderConfig{
-					APIVersion: crd.Spec.Group + "/v1",
-					Kind:       crd.Spec.Names.Kind,
+					APIVersion: crd.GetSpecGroup() + "/v1",
+					Kind:       crd.GetSpecNames().Kind,
 				},
 			},
 			want: want{
@@ -230,7 +231,10 @@ func TestProviderConfigDefinition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.mrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.mrd, got,
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
+			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/unstructured/customresourcedefinition.go
+++ b/internal/unstructured/customresourcedefinition.go
@@ -1,0 +1,147 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unstructured
+
+import (
+	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	apiVersion = "apiextensions.k8s.io/v1"
+	kind       = "CustomResourceDefinition"
+	kindList   = "CustomResourceDefinitionList"
+)
+
+// CustomResourceDefinition wraps an underlying unstructured.Unstructured. We
+// elect to use this type as a mechanism for working with CRDs versus the core
+// CustomResourceDefinition type as a means to side step expensive
+// un/marhsaling.
+type CustomResourceDefinition struct {
+	unstructured.Unstructured
+}
+
+// CustomResourceDefinitionList wraps an underlying
+// unstructured.UnstructuredList. We elect to use this type as a mechanism for
+// working with CRDs versus the core CustomResourceDefinition type as a means
+// to side step expensive un/marhsaling.
+type CustomResourceDefinitionList struct {
+	unstructured.UnstructuredList
+}
+
+// NewCRD constructs a CustomResourceDefinition with APIVersion and Kind set.
+func NewCRD() *CustomResourceDefinition {
+	crd := &CustomResourceDefinition{}
+	crd.SetAPIVersion(apiVersion)
+	crd.SetKind(kind)
+
+	return crd
+}
+
+// NewCRDList constructs a CustomResourceDefinitionList with APIVersion and Kind set.
+func NewCRDList() *CustomResourceDefinitionList {
+	list := &CustomResourceDefinitionList{}
+	list.SetAPIVersion(apiVersion)
+	list.SetKind(kindList)
+
+	return list
+}
+
+// GetAPIVersion of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetAPIVersion() string {
+	return apiVersion
+}
+
+// GetKind of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetKind() string {
+	return kind
+}
+
+// GetUnstructured of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetUnstructured() *unstructured.Unstructured {
+	return &c.Unstructured
+}
+
+// GetSpecGroup of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetSpecGroup() string {
+	p, err := fieldpath.Pave(c.Object).GetString("spec.group")
+	if err != nil {
+		return ""
+	}
+	return p
+}
+
+// SetSpecGroup of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) SetSpecGroup(g string) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.group", g)
+}
+
+// GetSpecNames of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetSpecNames() kextv1.CustomResourceDefinitionNames {
+	out := kextv1.CustomResourceDefinitionNames{}
+	if err := fieldpath.Pave(c.Object).GetValueInto("spec.names", &out); err != nil {
+		return kextv1.CustomResourceDefinitionNames{}
+	}
+	return out
+}
+
+// SetSpecNames of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) SetSpecNames(n kextv1.CustomResourceDefinitionNames) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.names", n)
+}
+
+// GetSpecScope of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetSpecScope() kextv1.ResourceScope {
+	p, err := fieldpath.Pave(c.Object).GetString("spec.scope")
+	if err != nil {
+		return ""
+	}
+	return kextv1.ResourceScope(p)
+}
+
+// SetSpecScope of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) SetSpecScope(s kextv1.ResourceScope) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.scope", s)
+}
+
+// GetStatus of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetStatus() kextv1.CustomResourceDefinitionStatus {
+	out := kextv1.CustomResourceDefinitionStatus{}
+	if err := fieldpath.Pave(c.Object).GetValueInto("spec.status", &out); err != nil {
+		return kextv1.CustomResourceDefinitionStatus{}
+	}
+	return out
+}
+
+// SetStatus of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) SetStatus(s kextv1.CustomResourceDefinitionStatus) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.status", s)
+}
+
+// GetSpecVersions of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) GetSpecVersions() []kextv1.CustomResourceDefinitionVersion {
+	out := []kextv1.CustomResourceDefinitionVersion{}
+	if err := fieldpath.Pave(c.Object).GetValueInto("spec.versions", &out); err != nil {
+		return []kextv1.CustomResourceDefinitionVersion{}
+	}
+	return out
+}
+
+// SetSpecVersions of this CustomResourceDefinition.
+func (c *CustomResourceDefinition) SetSpecVersions(v []kextv1.CustomResourceDefinitionVersion) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.versions", v)
+}


### PR DESCRIPTION
### Description of your changes

This is a follow on to https://github.com/upbound/xgql/pull/114.

With the changes from #114, we saw that following resource utilization graphs (notably much better than prior to the change):
![Screen Shot 2023-04-21 at 5 50 18 PM](https://user-images.githubusercontent.com/2375126/233752989-687426de-228e-482b-b44f-b6d1e5b4d46f.png)

However as seen in the heap pprof after the fix:

![Screen Shot 2023-04-21 at 5 54 44 PM](https://user-images.githubusercontent.com/2375126/233753210-b3537652-3090-462c-9a32-6007a405948c.png)

There's memory consumption occurring in `JSONSchemaProps*`. As referenced in #114, we've seen high utilization when un/marshaling `CustomResourceDefinition`s; much of this comes from how expensive it is to process the `JSONSchemaProps*`. Fortunately, these pieces are necessary for producing the `CustomResource` Validators - which is unnecessary for `xgql`.

With that in mind, this PR moves to using `Unstructured` instead of the full `CustomResourceDefinition` types. With just that adjustment we see the following differences:

Heap pprof:
![Screen Shot 2023-04-21 at 6 00 13 PM](https://user-images.githubusercontent.com/2375126/233753449-d941589b-b8fe-4f6b-b9c0-446b794e0d94.png)

Utilization graphs:
![Screen Shot 2023-04-21 at 6 00 42 PM](https://user-images.githubusercontent.com/2375126/233753476-b2c0379d-3e4e-47af-b671-ef982ab7467e.png)

That's great. However, we didn't stop there. While grabbing pprofs, I saw that we were still spending quite a bit of time marshaling types:
![Screen Shot 2023-04-21 at 6 04 25 PM](https://user-images.githubusercontent.com/2375126/233753657-d204284f-1635-43fc-a1a7-56b69981157b.png)

Due to this, I moved to using the standard `encoding/json` package which had a positive impact, but then I saw a bit of time spent in `unstruct()`:
![Screen Shot 2023-04-21 at 6 07 24 PM](https://user-images.githubusercontent.com/2375126/233753777-a6bc8ceb-a307-4262-8934-70472d30cb4c.png)

Due to this, I moved to using json/v2 which was the approach implemented upstream in k8s-api-server for the 1.26 to help with marshaling types, which ended having additional positive impacts:
![Screen Shot 2023-04-21 at 6 10 41 PM](https://user-images.githubusercontent.com/2375126/233753905-5b497833-6c7e-4cdf-af53-798fc51583e2.png)

Lastly, I saw that we were spending a bit of time in unstruct for our new `CustomResourceDefinition`s. In order to address that, I added a specialized method, which resulted in the final impacts on both heap and cpu:

Heap:
![Screen Shot 2023-04-21 at 6 13 00 PM](https://user-images.githubusercontent.com/2375126/233753992-48f7eea5-ec6a-421c-803a-e7a2dde1da09.png)

CPU:
![Screen Shot 2023-04-21 at 6 14 05 PM](https://user-images.githubusercontent.com/2375126/233754042-c617985f-d49f-4a4b-aaa0-459d63dfb144.png)


Highlevel changes:
- [X] add new unstructured.CustomResourceDefintion
- [X] add new unstructured.CustomResourceDefinitionList
- [X] specify that we don't have the informers cache extv1.CustomResourceDefinitions
- [X] add new specifialized bytesForUnstructured to remove unnecessary overhead for Marshaling unstuctured objects that are simply being returned as []byte
- [X] move to using json/v2 to take advantage of better un/marshal performance similar to 1.27 in the api-server

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Ensured the artifacts built and tests passed (`make test build.all`)
2. Deployed the image into the environment referenced in #114 and verified queries still worked and data still rendered.
