### PR TITLE
Move ProviderRevisionStatus Objects back to using CRDs

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -91,7 +91,6 @@ var noCache = []client.Object{
 	&appsv1.DaemonSet{},
 	&rbacv1.RoleBinding{},
 	&rbacv1.ClusterRoleBinding{},
-	&kextv1.CustomResourceDefinition{},
 
 	// We don't cache secrets because there's a high risk that the caller won't
 	// have access to list and watch secrets across all namespaces.

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -64,11 +64,8 @@ func Config() (*rest.Config, error) {
 		return nil, errors.Wrap(err, "cannot create in-cluster configuration")
 	}
 
-	// ctrl.GetConfig tunes QPS and burst for Kubernetes controllers. We're not
-	// a controller and we expect to be creating many clients, so we tune these
-	// back down to the client-go defaults.
-	cfg.QPS = 5
-	cfg.Burst = 20
+	cfg.QPS = 50
+	cfg.Burst = 300
 
 	cfg.UserAgent = "xgql/" + version.Version
 
@@ -84,8 +81,8 @@ func Config() (*rest.Config, error) {
 // than once every 20 seconds.
 func RESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
 	dcfg := rest.CopyConfig(cfg)
-	dcfg.QPS = 20
-	dcfg.Burst = 100
+	dcfg.QPS = 50
+	dcfg.Burst = 300
 
 	return apiutil.NewDynamicRESTMapper(dcfg, apiutil.WithLimiter(rate.NewLimiter(rate.Limit(0.05), 1)))
 }

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -368,6 +368,29 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition) Cus
 	}
 }
 
+// GetCustomResourceDefinitionFromCRD from the suppled Kubernetes CRD.
+func GetCustomResourceDefinitionFromCRD(crd *kextv1.CustomResourceDefinition) CustomResourceDefinition {
+	return CustomResourceDefinition{
+		ID: ReferenceID{
+			APIVersion: crd.APIVersion,
+			Kind:       crd.Kind,
+			Name:       crd.GetName(),
+		},
+
+		APIVersion: crd.APIVersion,
+		Kind:       crd.Kind,
+		Metadata:   GetObjectMeta(crd),
+		Spec: &CustomResourceDefinitionSpec{
+			Group:    crd.Spec.Group,
+			Names:    GetCustomResourceDefinitionNames(crd.Spec.Names),
+			Scope:    GetResourceScope(crd.Spec.Scope),
+			Versions: GetCustomResourceDefinitionVersions(crd.Spec.Versions),
+		},
+		Status:       GetCustomResourceDefinitionStatus(crd.Status),
+		Unstructured: unstruct(crd),
+	}
+}
+
 // GetKubernetesResource from the supplied unstructured Kubernetes resource.
 // GetKubernetesResource attempts to determine what type of resource the
 // unstructured data contains (e.g. a managed resource, a provider, etc) and

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/upbound/xgql/internal/auth"
 	"github.com/upbound/xgql/internal/graph/model"
-	"github.com/upbound/xgql/internal/unstructured"
 )
 
 const (
@@ -174,13 +173,13 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 			continue
 		}
 
-		crd := unstructured.NewCRD()
+		crd := &kextv1.CustomResourceDefinition{}
 		if err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, crd); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd))
+		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinitionFromCRD(crd))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/generated"
 	"github.com/upbound/xgql/internal/graph/model"
-	"github.com/upbound/xgql/internal/unstructured"
 )
 
 var (
@@ -317,7 +316,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinition(&unstructured.CustomResourceDefinition{})
+	gcrd := model.GetCustomResourceDefinitionFromCRD(&kextv1.CustomResourceDefinition{})
 
 	type args struct {
 		ctx context.Context


### PR DESCRIPTION
### Description of your changes
- It looks like unstructured.Unstructured calls are not being cached. This is resulting in this more expensive query timing out and failing.
- Moving back to CRDs as a near term workaround until we can determine why Unstructured is not being cached.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. make build test
2. Performed a query that resulted in all CRDs being looked up. Noted that query time was 5 seconds with a cold cache, 1 second with a warm cache, compared to the query timing out previously.
