### PR TITLE
Utilize unstructured informer cache

### DIFF
--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -66,10 +66,8 @@ func (r *xrd) getCrd(ctx context.Context, group string, names *model.CompositeRe
 	}
 
 	nn := types.NamespacedName{Name: fmt.Sprintf("%s.%s", names.Plural, group)}
-	in := &unstructured.CustomResourceDefinition{}
-	in.SetAPIVersion("apiextensions.k8s.io/v1")
-	in.SetKind("CustomResourceDefinition")
-	if err := c.Get(ctx, nn, in); err != nil {
+	in := unstructured.NewCRD()
+	if err := c.Get(ctx, nn, in.GetUnstructured()); err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
 		return nil, nil
 	}

--- a/internal/graph/resolvers/managed.go
+++ b/internal/graph/resolvers/managed.go
@@ -75,7 +75,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 
 	nn := types.NamespacedName{Name: fmt.Sprintf("%s.%s", name, gv.Group)}
 	in := unstructured.NewCRD()
-	err = c.Get(ctx, nn, in)
+	err = c.Get(ctx, nn, in.GetUnstructured())
 
 	if err != nil && !kerrors.IsNotFound(err) {
 		graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
@@ -86,7 +86,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 	// can find the matching one.
 	if kerrors.IsNotFound(err) {
 		lin := unstructured.NewCRDList()
-		if err := c.List(ctx, lin); err != nil {
+		if err := c.List(ctx, lin.GetUnstructuredList()); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errListCRDs))
 			return nil, nil
 		}

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -142,7 +142,7 @@ func TestManagedResourceDefinition(t *testing.T) {
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						*obj.(*unstructured.CustomResourceDefinition) = *crd
+						*obj.(*kunstructured.Unstructured) = *crd.GetUnstructured()
 						return nil
 					}),
 				}, nil
@@ -168,10 +168,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 						return errNotFound
 					}),
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
-							UnstructuredList: kunstructured.UnstructuredList{
-								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured, crdDifferingPlural.Unstructured},
-							},
+						*obj.(*kunstructured.UnstructuredList) = kunstructured.UnstructuredList{
+							Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured, crdDifferingPlural.Unstructured},
 						}
 						return nil
 					}),
@@ -196,10 +194,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 						return errNotFound
 					}),
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
-							UnstructuredList: kunstructured.UnstructuredList{
-								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured},
-							},
+						*obj.(*kunstructured.UnstructuredList) = kunstructured.UnstructuredList{
+							Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured},
 						}
 						return nil
 					}),

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/upbound/xgql/internal/auth"
 	"github.com/upbound/xgql/internal/graph/model"
+	xunstructured "github.com/upbound/xgql/internal/unstructured"
 )
 
 const (
@@ -173,13 +174,13 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 			continue
 		}
 
-		crd := &kextv1.CustomResourceDefinition{}
-		if err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, crd); err != nil {
+		crd := xunstructured.NewCRD()
+		if err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, crd.GetUnstructured()); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinitionFromCRD(crd))
+		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/generated"
 	"github.com/upbound/xgql/internal/graph/model"
+	xunstructured "github.com/upbound/xgql/internal/unstructured"
 )
 
 var (
@@ -316,7 +317,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinitionFromCRD(&kextv1.CustomResourceDefinition{})
+	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{})
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/providerconfig.go
+++ b/internal/graph/resolvers/providerconfig.go
@@ -74,7 +74,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 	nn := types.NamespacedName{Name: fmt.Sprintf("%s.%s", name, gv.Group)}
 
 	in := unstructured.NewCRD()
-	err = c.Get(ctx, nn, in)
+	err = c.Get(ctx, nn, in.GetUnstructured())
 
 	if err != nil && !kerrors.IsNotFound(err) {
 		graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
@@ -85,7 +85,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 	// can find the matching one.
 	if kerrors.IsNotFound(err) {
 		lin := unstructured.NewCRDList()
-		if err := c.List(ctx, lin); err != nil {
+		if err := c.List(ctx, lin.GetUnstructuredList()); err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errListCRDs))
 			return nil, nil
 		}

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -140,7 +140,7 @@ func TestProviderConfigDefinition(t *testing.T) {
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
-						*obj.(*unstructured.CustomResourceDefinition) = *crd
+						*obj.(*kunstructured.Unstructured) = *crd.GetUnstructured()
 						return nil
 					}),
 				}, nil
@@ -166,10 +166,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 						return errNotFound
 					}),
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
-							UnstructuredList: kunstructured.UnstructuredList{
-								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured, crdDifferingPlural.Unstructured},
-							},
+						*obj.(*kunstructured.UnstructuredList) = kunstructured.UnstructuredList{
+							Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured, crdDifferingPlural.Unstructured},
 						}
 						return nil
 					}),
@@ -194,10 +192,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 						return errNotFound
 					}),
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*unstructured.CustomResourceDefinitionList) = unstructured.CustomResourceDefinitionList{
-							UnstructuredList: kunstructured.UnstructuredList{
-								Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured},
-							},
+						*obj.(*kunstructured.UnstructuredList) = kunstructured.UnstructuredList{
+							Items: []kunstructured.Unstructured{otherGroup.Unstructured, otherKind.Unstructured},
 						}
 						return nil
 					}),

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -335,7 +335,7 @@ func (r *query) CustomResourceDefinitions(ctx context.Context, revision *model.R
 	}
 
 	in := xunstructured.NewCRDList()
-	if err := c.List(ctx, in); err != nil {
+	if err := c.List(ctx, in.GetUnstructuredList()); err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errListConfigs))
 		return nil, nil
 	}

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -1067,12 +1067,10 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*xunstructured.CustomResourceDefinitionList) = xunstructured.CustomResourceDefinitionList{
-							UnstructuredList: unstructured.UnstructuredList{
-								Items: []unstructured.Unstructured{
-									dangler.Unstructured,
-									owned.Unstructured,
-								},
+						*obj.(*unstructured.UnstructuredList) = unstructured.UnstructuredList{
+							Items: []unstructured.Unstructured{
+								dangler.Unstructured,
+								owned.Unstructured,
 							},
 						}
 						return nil
@@ -1097,12 +1095,10 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
 				return &test.MockClient{
 					MockList: test.NewMockListFn(nil, func(obj client.ObjectList) error {
-						*obj.(*xunstructured.CustomResourceDefinitionList) = xunstructured.CustomResourceDefinitionList{
-							UnstructuredList: unstructured.UnstructuredList{
-								Items: []unstructured.Unstructured{
-									dangler.Unstructured,
-									owned.Unstructured,
-								},
+						*obj.(*unstructured.UnstructuredList) = unstructured.UnstructuredList{
+							Items: []unstructured.Unstructured{
+								dangler.Unstructured,
+								owned.Unstructured,
 							},
 						}
 						return nil

--- a/internal/unstructured/customresourcedefinition.go
+++ b/internal/unstructured/customresourcedefinition.go
@@ -76,6 +76,11 @@ func (c *CustomResourceDefinition) GetUnstructured() *unstructured.Unstructured 
 	return &c.Unstructured
 }
 
+// GetUnstructuredList of this CustomResourceDefinitionList.
+func (c *CustomResourceDefinitionList) GetUnstructuredList() *unstructured.UnstructuredList {
+	return &c.UnstructuredList
+}
+
 // GetSpecGroup of this CustomResourceDefinition.
 func (c *CustomResourceDefinition) GetSpecGroup() string {
 	p, err := fieldpath.Pave(c.Object).GetString("spec.group")


### PR DESCRIPTION
### Description of your changes
- switch to using the underlying unstructured.Unstructured and unstructured.UnstructuredList types that the underlying cache mechanisms recognize
- update tests

After https://github.com/upbound/xgql/pull/116, this one was a bit of a 🤦. Spinning up a separate test and stepping through the client.Get calls, the new unstructured.CustomResourceDefinition types were not recognized as unstructured.Unstructured which resulted in the cache not being utilized.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. `make test build.all`
2. Tested against a scenario in which 900+ CRDs are queried within 1 GraphQL query. The result came back as quickly as the call invocation that was utilizing CRDs and the informer cache.
