### PR TITLE
performance improvements

### DIFF
--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -155,8 +155,8 @@ func GetCompositionStatus(in extv1.CompositionStatus) *CompositionStatus {
 }
 
 // GetComposition from the supplied Crossplane Composition.
-func GetComposition(cmp *extv1.Composition) Composition {
-	return Composition{
+func GetComposition(cmp *extv1.Composition, s SelectedFields) Composition {
+	out := Composition{
 		ID: ReferenceID{
 			APIVersion: cmp.APIVersion,
 			Kind:       cmp.Kind,
@@ -172,9 +172,12 @@ func GetComposition(cmp *extv1.Composition) Composition {
 			},
 			WriteConnectionSecretsToNamespace: cmp.Spec.WriteConnectionSecretsToNamespace,
 		},
-		Status:       GetCompositionStatus(cmp.Status),
-		Unstructured: unstruct(cmp),
+		Status: GetCompositionStatus(cmp.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(cmp)
+	}
+	return out
 }
 
 /* Handle deprecated items preferring non-deprecated */

--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -120,8 +120,8 @@ func GetCompositeResourceDefinitionStatus(in extv1.CompositeResourceDefinitionSt
 }
 
 // GetCompositeResourceDefinition from the supplied Crossplane XRD.
-func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition) CompositeResourceDefinition {
-	return CompositeResourceDefinition{
+func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition, s SelectedFields) CompositeResourceDefinition {
+	out := CompositeResourceDefinition{
 		ID: ReferenceID{
 			APIVersion: xrd.APIVersion,
 			Kind:       xrd.Kind,
@@ -138,9 +138,12 @@ func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition) Comp
 			DefaultCompositionReference:  xrd.Spec.DefaultCompositionRef,
 			EnforcedCompositionReference: xrd.Spec.EnforcedCompositionRef,
 		},
-		Status:       GetCompositeResourceDefinitionStatus(xrd.Status),
-		Unstructured: unstruct(xrd),
+		Status: GetCompositeResourceDefinitionStatus(xrd.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(xrd)
+	}
+	return out
 }
 
 // GetCompositionStatus from the supplied Crossplane status.

--- a/internal/graph/model/apiextensions_test.go
+++ b/internal/graph/model/apiextensions_test.go
@@ -162,8 +162,8 @@ func TestGetCompositeResourceDefinition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResourceDefinition(tc.xrd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CompositeResourceDefinition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetCompositeResourceDefinition(tc.xrd, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCompositeResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/apiextensions_test.go
+++ b/internal/graph/model/apiextensions_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -241,8 +240,8 @@ func TestGetComposition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetComposition(tc.xrd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Composition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetComposition(tc.xrd, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetComposition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -334,7 +334,7 @@ func GetCustomResourceDefinitionFromCRD(crd *kextv1.CustomResourceDefinition) Cu
 // unstructured data contains (e.g. a managed resource, a provider, etc) and
 // return the appropriate model type. If no type can be detected it returns a
 // GenericResource.
-func GetKubernetesResource(u *kunstructured.Unstructured) (KubernetesResource, error) { //nolint:gocyclo
+func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (KubernetesResource, error) { //nolint:gocyclo
 	// This isn't _really_ that complex; it's a long but simple switch.
 
 	switch {
@@ -368,7 +368,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured) (KubernetesResource, e
 		if err := convert(u, pr); err != nil {
 			return nil, errors.Wrap(err, "cannot convert provider revision")
 		}
-		return GetProviderRevision(pr), nil
+		return GetProviderRevision(pr, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ConfigurationGroupVersionKind:
 		c := &pkgv1.Configuration{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -396,7 +396,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, cmp); err != nil {
 			return nil, errors.Wrap(err, "cannot convert composition")
 		}
-		return GetComposition(cmp), nil
+		return GetComposition(cmp, s), nil
 
 	case u.GroupVersionKind() == schema.GroupVersionKind{Group: kextv1.GroupName, Version: "v1", Kind: "CustomResourceDefinition"}:
 		crd := &unstructured.CustomResourceDefinition{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -109,19 +109,22 @@ func GetLabelSelector(s *metav1.LabelSelector) *LabelSelector {
 }
 
 // GetGenericResource from the suppled Kubernetes resource.
-func GetGenericResource(u *kunstructured.Unstructured) GenericResource {
-	return GenericResource{
+func GetGenericResource(u *kunstructured.Unstructured, s SelectedFields) GenericResource {
+	out := GenericResource{
 		ID: ReferenceID{
 			APIVersion: u.GetAPIVersion(),
 			Kind:       u.GetKind(),
 			Namespace:  u.GetNamespace(),
 			Name:       u.GetName(),
 		},
-		APIVersion:   u.GetAPIVersion(),
-		Kind:         u.GetKind(),
-		Metadata:     GetObjectMeta(u),
-		Unstructured: bytesForUnstructured(u),
+		APIVersion: u.GetAPIVersion(),
+		Kind:       u.GetKind(),
+		Metadata:   GetObjectMeta(u),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }
 
 // Data of this secret.
@@ -431,7 +434,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		return GetConfigMap(cm, s), nil
 
 	default:
-		return GetGenericResource(u), nil
+		return GetGenericResource(u, s), nil
 	}
 }
 

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -284,8 +284,8 @@ func GetCustomResourceDefinitionStatus(in kextv1.CustomResourceDefinitionStatus)
 }
 
 // GetCustomResourceDefinition from the suppled Kubernetes CRD.
-func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition) CustomResourceDefinition {
-	return CustomResourceDefinition{
+func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition, s SelectedFields) CustomResourceDefinition {
+	out := CustomResourceDefinition{
 		ID: ReferenceID{
 			APIVersion: crd.GetAPIVersion(),
 			Kind:       crd.GetKind(),
@@ -301,9 +301,12 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition) Cus
 			Scope:    GetResourceScope(crd.GetSpecScope()),
 			Versions: GetCustomResourceDefinitionVersions(crd.GetSpecVersions()),
 		},
-		Status:       GetCustomResourceDefinitionStatus(crd.GetStatus()),
-		Unstructured: bytesForUnstructured(&crd.Unstructured),
+		Status: GetCustomResourceDefinitionStatus(crd.GetStatus()),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(&crd.Unstructured)
+	}
+	return out
 }
 
 // GetCustomResourceDefinitionFromCRD from the suppled Kubernetes CRD.
@@ -405,7 +408,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, crd); err != nil {
 			return nil, errors.Wrap(err, "cannot convert custom resource definition")
 		}
-		return GetCustomResourceDefinition(crd), nil
+		return GetCustomResourceDefinition(crd, s), nil
 
 	case u.GroupVersionKind() == schema.GroupVersionKind{Group: corev1.GroupName, Version: "v1", Kind: "Secret"}:
 		sec := &corev1.Secret{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -375,7 +375,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, c); err != nil {
 			return nil, errors.Wrap(err, "cannot convert configuration")
 		}
-		return GetConfiguration(c), nil
+		return GetConfiguration(c, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ConfigurationRevisionGroupVersionKind:
 		cr := &pkgv1.ConfigurationRevision{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -361,7 +361,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, p); err != nil {
 			return nil, errors.Wrap(err, "cannot convert provider")
 		}
-		return GetProvider(p), nil
+		return GetProvider(p, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ProviderRevisionGroupVersionKind:
 		pr := &pkgv1.ProviderRevision{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -185,20 +185,23 @@ func GetSecret(s *corev1.Secret, sel SelectedFields) Secret {
 }
 
 // GetConfigMap from the supplied Kubernetes ConfigMap.
-func GetConfigMap(cm *corev1.ConfigMap) ConfigMap {
-	return ConfigMap{
+func GetConfigMap(cm *corev1.ConfigMap, s SelectedFields) ConfigMap {
+	out := ConfigMap{
 		ID: ReferenceID{
 			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "ConfigMap",
 			Namespace:  cm.GetNamespace(),
 			Name:       cm.GetName(),
 		},
-		APIVersion:   corev1.SchemeGroupVersion.String(),
-		Kind:         "ConfigMap",
-		Metadata:     GetObjectMeta(cm),
-		Unstructured: unstruct(cm),
-		data:         cm.Data,
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "ConfigMap",
+		Metadata:   GetObjectMeta(cm),
+		data:       cm.Data,
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(cm)
+	}
+	return out
 }
 
 // GetCustomResourceDefinitionNames from the supplied Kubernetes names.
@@ -425,7 +428,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, cm); err != nil {
 			return nil, errors.Wrap(err, "cannot convert config map")
 		}
-		return GetConfigMap(cm), nil
+		return GetConfigMap(cm, s), nil
 
 	default:
 		return GetGenericResource(u), nil

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -346,7 +346,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		return GetCompositeResource(u, s), nil
 
 	case unstructured.ProbablyClaim(u):
-		return GetCompositeResourceClaim(u), nil
+		return GetCompositeResourceClaim(u, s), nil
 
 	// Note that order is important here. We want to check whether the resource
 	// seems to be a managed resource _after_ checking whether it seems to be a

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -382,7 +382,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, cr); err != nil {
 			return nil, errors.Wrap(err, "cannot convert configuration revision")
 		}
-		return GetConfigurationRevision(cr), nil
+		return GetConfigurationRevision(cr, s), nil
 
 	case u.GroupVersionKind() == extv1.CompositeResourceDefinitionGroupVersionKind:
 		xrd := &extv1.CompositeResourceDefinition{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -354,7 +354,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 	// that would pass the ProbablyManaged check. Such a composite resource
 	// would very likely pass the ProbablyComposite check and never reach this.
 	case unstructured.ProbablyManaged(u):
-		return GetManagedResource(u), nil
+		return GetManagedResource(u, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ProviderGroupVersionKind:
 		p := &pkgv1.Provider{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -318,29 +318,6 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition, s S
 	return out
 }
 
-// GetCustomResourceDefinitionFromCRD from the suppled Kubernetes CRD.
-func GetCustomResourceDefinitionFromCRD(crd *kextv1.CustomResourceDefinition) CustomResourceDefinition {
-	return CustomResourceDefinition{
-		ID: ReferenceID{
-			APIVersion: crd.APIVersion,
-			Kind:       crd.Kind,
-			Name:       crd.GetName(),
-		},
-
-		APIVersion: crd.APIVersion,
-		Kind:       crd.Kind,
-		Metadata:   GetObjectMeta(crd),
-		Spec: CustomResourceDefinitionSpec{
-			Group:    crd.Spec.Group,
-			Names:    *GetCustomResourceDefinitionNames(crd.Spec.Names),
-			Scope:    GetResourceScope(crd.Spec.Scope),
-			Versions: GetCustomResourceDefinitionVersions(crd.Spec.Versions),
-		},
-		Status:       GetCustomResourceDefinitionStatus(crd.Status),
-		Unstructured: unstruct(crd),
-	}
-}
-
 // GetKubernetesResource from the supplied unstructured Kubernetes resource.
 // GetKubernetesResource attempts to determine what type of resource the
 // unstructured data contains (e.g. a managed resource, a provider, etc) and

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -343,7 +343,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		return GetProviderConfig(u, s), nil
 
 	case unstructured.ProbablyComposite(u):
-		return GetCompositeResource(u), nil
+		return GetCompositeResource(u, s), nil
 
 	case unstructured.ProbablyClaim(u):
 		return GetCompositeResourceClaim(u), nil

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -340,7 +340,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 	switch {
 
 	case unstructured.ProbablyProviderConfig(u):
-		return GetProviderConfig(u), nil
+		return GetProviderConfig(u, s), nil
 
 	case unstructured.ProbablyComposite(u):
 		return GetCompositeResource(u), nil

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -389,7 +389,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, xrd); err != nil {
 			return nil, errors.Wrap(err, "cannot convert composite resource definition")
 		}
-		return GetCompositeResourceDefinition(xrd), nil
+		return GetCompositeResourceDefinition(xrd, s), nil
 
 	case u.GroupVersionKind() == extv1.CompositionGroupVersionKind:
 		cmp := &extv1.Composition{}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -735,7 +735,7 @@ func TestGetKubernetesResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			kr, err := GetKubernetesResource(tc.u)
+			kr, err := GetKubernetesResource(tc.u, SelectAll)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("GetKubernetesResource(...): -want error, +got error:\n%s", diff)
 			}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -110,8 +110,8 @@ func TestGetGenericResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetGenericResource(tc.u)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(GenericResource{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetGenericResource(tc.u, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetGenericResource(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -309,8 +309,8 @@ func TestGetConfigMap(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfigMap(tc.cm)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigMap{}, "Unstructured"), cmp.AllowUnexported(ConfigMap{}, ObjectMeta{})); diff != "" {
+			got := GetConfigMap(tc.cm, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ConfigMap{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -431,20 +430,6 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 func TestGetKubernetesResource(t *testing.T) {
 	ignore := []cmp.Option{
 		cmp.AllowUnexported(Secret{}, ConfigMap{}, ObjectMeta{}),
-		cmpopts.IgnoreFields(ManagedResource{}, "Unstructured"),
-		cmpopts.IgnoreFields(ProviderConfig{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResource{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResourceClaim{}, "Unstructured"),
-		cmpopts.IgnoreFields(Provider{}, "Unstructured"),
-		cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"),
-		cmpopts.IgnoreFields(Configuration{}, "Unstructured"),
-		cmpopts.IgnoreFields(ConfigurationRevision{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResourceDefinition{}, "Unstructured"),
-		cmpopts.IgnoreFields(Composition{}, "Unstructured"),
-		cmpopts.IgnoreFields(CustomResourceDefinition{}, "Unstructured"),
-		cmpopts.IgnoreFields(Secret{}, "Unstructured"),
-		cmpopts.IgnoreFields(ConfigMap{}, "Unstructured"),
-		cmpopts.IgnoreFields(GenericResource{}, "Unstructured"),
 	}
 
 	dp := DeletionPolicyDelete
@@ -735,7 +720,7 @@ func TestGetKubernetesResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			kr, err := GetKubernetesResource(tc.u, SelectAll)
+			kr, err := GetKubernetesResource(tc.u, SkipFields(FieldUnstructured))
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("GetKubernetesResource(...): -want error, +got error:\n%s", diff)
 			}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -211,8 +211,8 @@ func TestGetSecret(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetSecret(tc.s)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Secret{}, "Unstructured"), cmp.AllowUnexported(Secret{}, ObjectMeta{})); diff != "" {
+			got := GetSecret(tc.s, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(Secret{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -420,8 +420,8 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCustomResourceDefinition(tc.crd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CustomResourceDefinition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetCustomResourceDefinition(tc.crd, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCustomResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -124,9 +124,9 @@ func GetCompositeResourceClaimStatus(xrc *unstructured.Claim) *CompositeResource
 }
 
 // GetCompositeResourceClaim from the supplied Crossplane claim.
-func GetCompositeResourceClaim(u *kunstructured.Unstructured) CompositeResourceClaim {
+func GetCompositeResourceClaim(u *kunstructured.Unstructured, s SelectedFields) CompositeResourceClaim {
 	xrc := &unstructured.Claim{Unstructured: *u}
-	return CompositeResourceClaim{
+	out := CompositeResourceClaim{
 		ID: ReferenceID{
 			APIVersion: xrc.GetAPIVersion(),
 			Kind:       xrc.GetKind(),
@@ -143,7 +143,10 @@ func GetCompositeResourceClaim(u *kunstructured.Unstructured) CompositeResourceC
 			ResourceReference:                xrc.GetResourceReference(),
 			WriteConnectionSecretToReference: delocalize(xrc.GetWriteConnectionSecretToReference(), xrc.GetNamespace()),
 		},
-		Status:       GetCompositeResourceClaimStatus(xrc),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetCompositeResourceClaimStatus(xrc),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -76,7 +76,7 @@ func GetCompositeResource(u *kunstructured.Unstructured, s SelectedFields) Compo
 		},
 		Status: GetCompositeResourceStatus(xr),
 	}
-	if s.Has("unstructured") {
+	if s.Has(FieldUnstructured) {
 		out.Unstructured = bytesForUnstructured(u)
 	}
 	return out

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -55,9 +55,9 @@ func GetCompositeResourceStatus(xr *unstructured.Composite) *CompositeResourceSt
 }
 
 // GetCompositeResource from the supplied Crossplane resource.
-func GetCompositeResource(u *kunstructured.Unstructured) CompositeResource {
+func GetCompositeResource(u *kunstructured.Unstructured, s SelectedFields) CompositeResource {
 	xr := &unstructured.Composite{Unstructured: *u}
-	return CompositeResource{
+	out := CompositeResource{
 		ID: ReferenceID{
 			APIVersion: xr.GetAPIVersion(),
 			Kind:       xr.GetKind(),
@@ -74,9 +74,12 @@ func GetCompositeResource(u *kunstructured.Unstructured) CompositeResource {
 			ResourceReferences:               xr.GetResourceReferences(),
 			WriteConnectionSecretToReference: xr.GetWriteConnectionSecretToReference(),
 		},
-		Status:       GetCompositeResourceStatus(xr),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetCompositeResourceStatus(xr),
 	}
+	if s.Has("unstructured") {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }
 
 func delocalize(ref *xpv1.LocalSecretReference, namespace string) *xpv1.SecretReference {

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -179,11 +179,10 @@ func TestGetCompositeResourceClaim(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResourceClaim(tc.u)
+			got := GetCompositeResourceClaim(tc.u, SkipFields(FieldUnstructured))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,
-				cmpopts.IgnoreFields(CompositeResourceClaim{}, "Unstructured"),
 				cmpopts.EquateApproxTime(1*time.Second),
 				cmp.AllowUnexported(ObjectMeta{}),
 			); diff != "" {

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -100,7 +100,7 @@ func TestGetCompositeResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResource(tc.u, SkipFields("unstructured"))
+			got := GetCompositeResource(tc.u, SkipFields(FieldUnstructured))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -100,11 +100,10 @@ func TestGetCompositeResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResource(tc.u)
+			got := GetCompositeResource(tc.u, SkipFields("unstructured"))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,
-				cmpopts.IgnoreFields(CompositeResource{}, "Unstructured"),
 				cmpopts.EquateApproxTime(1*time.Second),
 				cmp.AllowUnexported(ObjectMeta{}),
 			); diff != "" {

--- a/internal/graph/model/event.go
+++ b/internal/graph/model/event.go
@@ -34,7 +34,7 @@ func GetEventType(in string) *EventType {
 }
 
 // GetEvent from the supplied Kubernetes event.
-func GetEvent(e *corev1.Event) Event {
+func GetEvent(e *corev1.Event, s SelectedFields) Event {
 	out := Event{
 		ID: ReferenceID{
 			APIVersion: e.APIVersion,
@@ -46,7 +46,6 @@ func GetEvent(e *corev1.Event) Event {
 		Kind:              e.Kind,
 		Metadata:          GetObjectMeta(e),
 		Type:              GetEventType(e.Type),
-		Unstructured:      unstruct(e),
 		InvolvedObjectRef: e.InvolvedObject,
 	}
 
@@ -67,6 +66,10 @@ func GetEvent(e *corev1.Event) Event {
 	out.FirstTime = &ft
 	lt := e.LastTimestamp.Time
 	out.LastTime = &lt
+
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(e)
+	}
 
 	return out
 }

--- a/internal/graph/model/event_test.go
+++ b/internal/graph/model/event_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kschema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,8 +89,8 @@ func TestGetEvent(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetEvent(tc.s)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Event{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetEvent(tc.s, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetEvent(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/managed.go
+++ b/internal/graph/model/managed.go
@@ -62,9 +62,9 @@ func GetManagedResourceStatus(in *unstructured.Managed) *ManagedResourceStatus {
 }
 
 // GetManagedResource from the supplied Crossplane resource.
-func GetManagedResource(u *kunstructured.Unstructured) ManagedResource {
+func GetManagedResource(u *kunstructured.Unstructured, s SelectedFields) ManagedResource {
 	mg := &unstructured.Managed{Unstructured: *u}
-	return ManagedResource{
+	out := ManagedResource{
 		ID: ReferenceID{
 			APIVersion: mg.GetAPIVersion(),
 			Kind:       mg.GetKind(),
@@ -79,7 +79,10 @@ func GetManagedResource(u *kunstructured.Unstructured) ManagedResource {
 			ProviderConfigRef:                GetProviderConfigReference(mg.GetProviderConfigReference()),
 			DeletionPolicy:                   GetDeletionPolicy(mg.GetDeletionPolicy()),
 		},
-		Status:       GetManagedResourceStatus(mg),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetManagedResourceStatus(mg),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }

--- a/internal/graph/model/managed_test.go
+++ b/internal/graph/model/managed_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -88,9 +87,9 @@ func TestGetManagedResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetManagedResource(tc.u)
+			got := GetManagedResource(tc.u, SkipFields(FieldUnstructured))
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ManagedResource{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetManagedResource(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -93,8 +93,8 @@ func GetProviderStatus(in pkgv1.ProviderStatus) *ProviderStatus {
 }
 
 // GetProvider from the supplied Kubernetes provider.
-func GetProvider(p *pkgv1.Provider) Provider {
-	return Provider{
+func GetProvider(p *pkgv1.Provider, s SelectedFields) Provider {
+	out := Provider{
 		ID: ReferenceID{
 			APIVersion: p.APIVersion,
 			Kind:       p.Kind,
@@ -112,9 +112,12 @@ func GetProvider(p *pkgv1.Provider) Provider {
 			IgnoreCrossplaneConstraints: p.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    p.Spec.SkipDependencyResolution,
 		},
-		Status:       GetProviderStatus(p.Status),
-		Unstructured: unstruct(p),
+		Status: GetProviderStatus(p.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(p)
+	}
+	return out
 }
 
 // GetPackageRevisionDesiredState from the supplies Crossplane state.

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -145,8 +145,8 @@ func GetProviderRevisionStatus(in pkgv1.PackageRevisionStatus) *ProviderRevision
 }
 
 // GetProviderRevision from the supplied Crossplane provider revision.
-func GetProviderRevision(pr *pkgv1.ProviderRevision) ProviderRevision {
-	return ProviderRevision{
+func GetProviderRevision(pr *pkgv1.ProviderRevision, s SelectedFields) ProviderRevision {
+	out := ProviderRevision{
 		ID: ReferenceID{
 			APIVersion: pr.APIVersion,
 			Kind:       pr.Kind,
@@ -164,9 +164,12 @@ func GetProviderRevision(pr *pkgv1.ProviderRevision) ProviderRevision {
 			IgnoreCrossplaneConstraints: pr.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    pr.Spec.SkipDependencyResolution,
 		},
-		Status:       GetProviderRevisionStatus(pr.Status),
-		Unstructured: unstruct(pr),
+		Status: GetProviderRevisionStatus(pr.Status),
 	}
+	if s.Has("unstructured") {
+		out.Unstructured = unstruct(pr)
+	}
+	return out
 }
 
 // GetConfigurationStatus from the supplied Kubernetes status.

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -191,8 +191,8 @@ func GetConfigurationStatus(in pkgv1.ConfigurationStatus) *ConfigurationStatus {
 }
 
 // GetConfiguration from the supplied Kubernetes configuration.
-func GetConfiguration(c *pkgv1.Configuration) Configuration {
-	return Configuration{
+func GetConfiguration(c *pkgv1.Configuration, s SelectedFields) Configuration {
+	out := Configuration{
 		ID: ReferenceID{
 			APIVersion: c.APIVersion,
 			Kind:       c.Kind,
@@ -210,9 +210,12 @@ func GetConfiguration(c *pkgv1.Configuration) Configuration {
 			IgnoreCrossplaneConstraints: c.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    c.Spec.SkipDependencyResolution,
 		},
-		Status:       GetConfigurationStatus(c.Status),
-		Unstructured: unstruct(c),
+		Status: GetConfigurationStatus(c.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(c)
+	}
+	return out
 }
 
 // GetConfigurationRevisionStatus from the supplied Crossplane provider revision.

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -166,7 +166,7 @@ func GetProviderRevision(pr *pkgv1.ProviderRevision, s SelectedFields) ProviderR
 		},
 		Status: GetProviderRevisionStatus(pr.Status),
 	}
-	if s.Has("unstructured") {
+	if s.Has(FieldUnstructured) {
 		out.Unstructured = unstruct(pr)
 	}
 	return out

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -235,8 +235,8 @@ func GetConfigurationRevisionStatus(in pkgv1.PackageRevisionStatus) *Configurati
 }
 
 // GetConfigurationRevision from the supplied Kubernetes provider revision.
-func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision) ConfigurationRevision {
-	return ConfigurationRevision{
+func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision, s SelectedFields) ConfigurationRevision {
+	out := ConfigurationRevision{
 		ID: ReferenceID{
 			APIVersion: cr.APIVersion,
 			Kind:       cr.Kind,
@@ -254,7 +254,10 @@ func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision) ConfigurationRevi
 			IgnoreCrossplaneConstraints: cr.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    cr.Spec.SkipDependencyResolution,
 		},
-		Status:       GetConfigurationRevisionStatus(cr.Status),
-		Unstructured: unstruct(cr),
+		Status: GetConfigurationRevisionStatus(cr.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(cr)
+	}
+	return out
 }

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -110,8 +110,8 @@ func TestGetProvider(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProvider(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Provider{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetProvider(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProvider(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -212,7 +212,7 @@ func TestGetProviderRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderRevision(tc.cfg)
+			got := GetProviderRevision(tc.cfg, SelectAll)
 			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -302,8 +302,8 @@ func TestGetConfiguration(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfiguration(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Configuration{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetConfiguration(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfiguration(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,8 +211,8 @@ func TestGetProviderRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderRevision(tc.cfg, SelectAll)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetProviderRevision(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -404,8 +404,8 @@ func TestGetConfigurationRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfigurationRevision(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigurationRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetConfigurationRevision(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfigurationRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -38,19 +38,22 @@ func GetProviderConfigStatus(pc *unstructured.ProviderConfig) *ProviderConfigSta
 }
 
 // GetProviderConfig from the suppled Crossplane ProviderConfig.
-func GetProviderConfig(u *kunstructured.Unstructured) ProviderConfig {
+func GetProviderConfig(u *kunstructured.Unstructured, s SelectedFields) ProviderConfig {
 	pc := &unstructured.ProviderConfig{Unstructured: *u}
-	return ProviderConfig{
+	out := ProviderConfig{
 		ID: ReferenceID{
 			APIVersion: pc.GetAPIVersion(),
 			Kind:       pc.GetKind(),
 			Name:       pc.GetName(),
 		},
 
-		APIVersion:   pc.GetAPIVersion(),
-		Kind:         pc.GetKind(),
-		Metadata:     GetObjectMeta(pc),
-		Status:       GetProviderConfigStatus(pc),
-		Unstructured: bytesForUnstructured(u),
+		APIVersion: pc.GetAPIVersion(),
+		Kind:       pc.GetKind(),
+		Metadata:   GetObjectMeta(pc),
+		Status:     GetProviderConfigStatus(pc),
 	}
+	if s.Has("unstructured") {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -52,7 +52,7 @@ func GetProviderConfig(u *kunstructured.Unstructured, s SelectedFields) Provider
 		Metadata:   GetObjectMeta(pc),
 		Status:     GetProviderConfigStatus(pc),
 	}
-	if s.Has("unstructured") {
+	if s.Has(FieldUnstructured) {
 		out.Unstructured = bytesForUnstructured(u)
 	}
 	return out

--- a/internal/graph/model/providerconfig_test.go
+++ b/internal/graph/model/providerconfig_test.go
@@ -72,7 +72,7 @@ func TestGetProviderConfig(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderConfig(tc.u, SkipFields("unstructured"))
+			got := GetProviderConfig(tc.u, SkipFields(FieldUnstructured))
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderConfig(...): -want, +got\n:%s", tc.reason, diff)

--- a/internal/graph/model/providerconfig_test.go
+++ b/internal/graph/model/providerconfig_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -73,9 +72,9 @@ func TestGetProviderConfig(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderConfig(tc.u)
+			got := GetProviderConfig(tc.u, SkipFields("unstructured"))
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderConfig{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderConfig(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/selection.go
+++ b/internal/graph/model/selection.go
@@ -14,6 +14,11 @@
 
 package model
 
+const (
+	FieldUnstructured = "unstructured"
+	FieldNodes        = "nodes"
+)
+
 // SelectedFields allows checking if a field was selected in a GraphQL query.
 // It uses "." as a separator for nested fields.
 // Example:

--- a/internal/graph/model/selection.go
+++ b/internal/graph/model/selection.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// SelectedFields allows checking if a field was selected in a GraphQL query.
+// It uses "." as a separator for nested fields.
+// Example:
+//
+//	fields := GetSelectedFields(ctx)
+//	if fields.Has("user") {
+//	  // get base fields
+//	}
+//	if fields.Has("user.friends") {
+//	  // do some expensive operation
+//	}
+type SelectedFields interface {
+	Has(path string) bool
+}
+
+type selectFields bool
+
+func (s selectFields) Has(string) bool {
+	return bool(s)
+}
+
+var (
+	SelectAll  selectFields = true
+	SelectNone selectFields = false
+)
+
+type skipFields []string
+
+func (s skipFields) Has(path string) bool {
+	for _, f := range s {
+		if f == path {
+			return false
+		}
+		if len(f) > len(path) && f[:len(path)] == path && f[len(path)] == '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func SkipFields(paths ...string) SelectedFields {
+	return skipFields(paths)
+}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -75,7 +75,7 @@ func (r *xrd) getCrd(ctx context.Context, group string, names *model.CompositeRe
 		return nil, nil
 	}
 
-	out := model.GetCustomResourceDefinition(in)
+	out := model.GetCustomResourceDefinition(in, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -133,7 +133,7 @@ that is filtered and sorted
 */
 func getCompositeResourceConnection(ctx context.Context, in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceOptionsInput) model.CompositeResourceConnection {
 	xrs := []model.CompositeResource{}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		xr := model.GetCompositeResource(&in.Items[i], selectedFields)

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -124,18 +124,19 @@ func (r *xrd) DefinedCompositeResources(ctx context.Context, obj *model.Composit
 		return model.CompositeResourceConnection{}, nil
 	}
 
-	return getCompositeResourceConnection(in, options), nil
+	return getCompositeResourceConnection(ctx, in, options), nil
 }
 
 /*
 Produce a CompositeResourceClaimConnection from the raw k8s UnstructuredList
 that is filtered and sorted
 */
-func getCompositeResourceConnection(in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceOptionsInput) model.CompositeResourceConnection {
+func getCompositeResourceConnection(ctx context.Context, in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceOptionsInput) model.CompositeResourceConnection {
 	xrs := []model.CompositeResource{}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
-		xr := model.GetCompositeResource(&in.Items[i])
+		xr := model.GetCompositeResource(&in.Items[i], selectedFields)
 		if readyMatches(options.Ready, &xr) {
 			xrs = append(xrs, xr)
 		}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -199,18 +199,19 @@ func (r *xrd) DefinedCompositeResourceClaims(ctx context.Context, obj *model.Com
 		return model.CompositeResourceClaimConnection{}, nil
 	}
 
-	return getCompositeResourceClaimConnection(in, options), nil
+	return getCompositeResourceClaimConnection(ctx, in, options), nil
 }
 
 /*
 Produce a CompositeResourceClaimConnection from the raw k8s UnstructuredList
 that is filtered and sorted
 */
-func getCompositeResourceClaimConnection(in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceClaimOptionsInput) model.CompositeResourceClaimConnection {
+func getCompositeResourceClaimConnection(ctx context.Context, in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceClaimOptionsInput) model.CompositeResourceClaimConnection {
 	claims := []model.CompositeResourceClaim{}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
-		claim := model.GetCompositeResourceClaim(&in.Items[i])
+		claim := model.GetCompositeResourceClaim(&in.Items[i], selectedFields)
 		if readyMatches(options.Ready, &claim) {
 			claims = append(claims, claim)
 		}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -293,7 +293,7 @@ func (r *xrdSpec) DefaultComposition(ctx context.Context, obj *model.CompositeRe
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 
@@ -318,7 +318,7 @@ func (r *xrdSpec) EnforcedComposition(ctx context.Context, obj *model.CompositeR
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -269,16 +269,16 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xr := unstructured.Unstructured{}
-	gxr := model.GetCompositeResource(&xr)
+	gxr := model.GetCompositeResource(&xr, model.SelectAll)
 	xrReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrReady := model.GetCompositeResource(&xrReady)
+	gxrReady := model.GetCompositeResource(&xrReady, model.SelectAll)
 	xrNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrNotReady := model.GetCompositeResource(&xrNotReady)
+	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SelectAll)
 	xrReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown)
+	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SelectAll)
 
 	group := "example.org"
 	version := "v1"

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -1438,7 +1438,7 @@ func TestCompositeResourceDefinitionSpecDefaultComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -1569,7 +1569,7 @@ func TestCompositeResourceDefinitionSpecEnforcedComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -758,16 +758,16 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xrc := unstructured.Unstructured{}
-	gxrc := model.GetCompositeResourceClaim(&xrc)
+	gxrc := model.GetCompositeResourceClaim(&xrc, model.SelectAll)
 	xrcReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrcReady := model.GetCompositeResourceClaim(&xrcReady)
+	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SelectAll)
 	xrcNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady)
+	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SelectAll)
 	xrcReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown)
+	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SelectAll)
 
 	group := "example.org"
 	version := "v1"

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -144,7 +144,7 @@ func TestCompositeResourceCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -259,7 +259,7 @@ func TestCompositeResourceClaimCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -270,16 +270,16 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xr := unstructured.Unstructured{}
-	gxr := model.GetCompositeResource(&xr, model.SelectAll)
+	gxr := model.GetCompositeResource(&xr, model.SkipFields(model.FieldUnstructured))
 	xrReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrReady := model.GetCompositeResource(&xrReady, model.SelectAll)
+	gxrReady := model.GetCompositeResource(&xrReady, model.SkipFields(model.FieldUnstructured))
 	xrNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SelectAll)
+	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SkipFields(model.FieldUnstructured))
 	xrReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SelectAll)
+	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SkipFields(model.FieldUnstructured))
 
 	group := "example.org"
 	version := "v1"
@@ -747,7 +747,6 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.crc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResources(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -759,16 +758,16 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xrc := unstructured.Unstructured{}
-	gxrc := model.GetCompositeResourceClaim(&xrc, model.SelectAll)
+	gxrc := model.GetCompositeResourceClaim(&xrc, model.SkipFields(model.FieldUnstructured))
 	xrcReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SelectAll)
+	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SkipFields(model.FieldUnstructured))
 	xrcNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SelectAll)
+	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SkipFields(model.FieldUnstructured))
 	xrcReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SelectAll)
+	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SkipFields(model.FieldUnstructured))
 
 	group := "example.org"
 	version := "v1"
@@ -1424,7 +1423,6 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.crcc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/common.go
+++ b/internal/graph/resolvers/common.go
@@ -136,11 +136,12 @@ func (r *crd) DefinedResources(ctx context.Context, obj *model.CustomResourceDef
 		Nodes:      make([]model.KubernetesResource, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
 		u := in.Items[i]
 
-		kr, err := model.GetKubernetesResource(&u)
+		kr, err := model.GetKubernetesResource(&u, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelDefined))
 		}

--- a/internal/graph/resolvers/common.go
+++ b/internal/graph/resolvers/common.go
@@ -136,7 +136,7 @@ func (r *crd) DefinedResources(ctx context.Context, obj *model.CustomResourceDef
 		Nodes:      make([]model.KubernetesResource, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		u := in.Items[i]

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -193,6 +193,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ResourceReferences)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for _, ref := range obj.ResourceReferences {
 		// Ignore nameless resource references
@@ -209,7 +210,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 			continue
 		}
 
-		kr, err := model.GetKubernetesResource(xrc)
+		kr, err := model.GetKubernetesResource(xrc, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelComposed))
 			continue

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -252,7 +252,7 @@ func (r *compositeResourceSpec) ConnectionSecret(ctx context.Context, obj *model
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }
 
@@ -426,7 +426,7 @@ func (r *compositeResourceClaimSpec) ConnectionSecret(ctx context.Context, obj *
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -193,7 +193,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ResourceReferences)),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for _, ref := range obj.ResourceReferences {
 		// Ignore nameless resource references

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -390,7 +390,7 @@ func (r *compositeResourceClaimSpec) Resource(ctx context.Context, obj *model.Co
 		return nil, nil
 	}
 
-	out := model.GetCompositeResource(xr)
+	out := model.GetCompositeResource(xr, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -130,7 +130,7 @@ func (r *compositeResourceSpec) Composition(ctx context.Context, obj *model.Comp
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 
@@ -360,7 +360,7 @@ func (r *compositeResourceClaimSpec) Composition(ctx context.Context, obj *model
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -171,7 +171,7 @@ func (r *compositeResourceSpec) Claim(ctx context.Context, obj *model.CompositeR
 		return nil, nil
 	}
 
-	out := model.GetCompositeResourceClaim(xrc)
+	out := model.GetCompositeResourceClaim(xrc, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -92,7 +92,7 @@ func (r *compositeResource) Definition(ctx context.Context, obj *model.Composite
 			continue
 		}
 
-		out := model.GetCompositeResourceDefinition(&xrd)
+		out := model.GetCompositeResourceDefinition(&xrd, GetSelectedFields(ctx))
 		return &out, nil
 	}
 
@@ -314,7 +314,7 @@ func (r *compositeResourceClaim) Definition(ctx context.Context, obj *model.Comp
 			continue
 		}
 
-		out := model.GetCompositeResourceDefinition(&xrd)
+		out := model.GetCompositeResourceDefinition(&xrd, GetSelectedFields(ctx))
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -17,6 +17,7 @@ package resolvers
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -195,30 +196,43 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 	}
 	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
+	// Collect all concurrently.
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
 	for _, ref := range obj.ResourceReferences {
 		// Ignore nameless resource references
 		if ref.Name == "" {
 			continue
 		}
 
-		xrc := &unstructured.Unstructured{}
-		xrc.SetAPIVersion(ref.APIVersion)
-		xrc.SetKind(ref.Kind)
-		nn := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
-		if err := c.Get(ctx, nn, xrc); err != nil {
-			graphql.AddError(ctx, errors.Wrap(err, errGetComposed))
-			continue
-		}
+		ref := ref // So we don't take the address of a range variable.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			xrc := &unstructured.Unstructured{}
+			xrc.SetAPIVersion(ref.APIVersion)
+			xrc.SetKind(ref.Kind)
+			nn := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
+			if err := c.Get(ctx, nn, xrc); err != nil {
+				graphql.AddError(ctx, errors.Wrap(err, errGetComposed))
+				return
+			}
 
-		kr, err := model.GetKubernetesResource(xrc, selectedFields)
-		if err != nil {
-			graphql.AddError(ctx, errors.Wrap(err, errModelComposed))
-			continue
-		}
+			kr, err := model.GetKubernetesResource(xrc, selectedFields)
+			if err != nil {
+				graphql.AddError(ctx, errors.Wrap(err, errModelComposed))
+				return
+			}
 
-		out.Nodes = append(out.Nodes, kr)
-		out.TotalCount++
+			mu.Lock()
+			defer mu.Unlock()
+			out.Nodes = append(out.Nodes, kr)
+			out.TotalCount++
+		}()
 	}
+	wg.Wait()
 
 	sort.Stable(out)
 	return *out, nil

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -1245,7 +1245,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxr := model.GetCompositeResource(&unstructured.Unstructured{})
+	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -571,11 +571,11 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 
 	kra := &unstructured.Unstructured{}
 	kra.SetKind("A")
-	gkra, _ := model.GetKubernetesResource(kra)
+	gkra, _ := model.GetKubernetesResource(kra, model.SelectAll)
 
 	krb := &unstructured.Unstructured{}
 	krb.SetKind("B")
-	gkrb, _ := model.GetKubernetesResource(krb)
+	gkrb, _ := model.GetKubernetesResource(krb, model.SelectAll)
 
 	krc := &unstructured.Unstructured{}
 	krc.SetKind("C")

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -74,7 +74,7 @@ func TestCompositeResourceDefinition(t *testing.T) {
 		},
 	}
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -229,7 +229,7 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -994,7 +994,7 @@ func TestCompositeResourceClaimDefinition(t *testing.T) {
 		},
 	}
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -1149,7 +1149,7 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -438,7 +438,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SelectAll)
+	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -551,7 +551,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -628,11 +628,11 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 
 	kra := &unstructured.Unstructured{}
 	kra.SetKind("A")
-	gkra, _ := model.GetKubernetesResource(kra, model.SelectAll)
+	gkra, _ := model.GetKubernetesResource(kra, model.SkipFields(model.FieldUnstructured))
 
 	krb := &unstructured.Unstructured{}
 	krb.SetKind("B")
-	gkrb, _ := model.GetKubernetesResource(krb, model.SelectAll)
+	gkrb, _ := model.GetKubernetesResource(krb, model.SkipFields(model.FieldUnstructured))
 
 	krc := &unstructured.Unstructured{}
 	krc.SetKind("C")
@@ -764,7 +764,7 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1383,7 +1383,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SelectAll)
+	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -1496,7 +1496,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -381,7 +381,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{})
+	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -226,7 +226,15 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gcmp := model.GetComposition(&extv1.Composition{})
+	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "nodes.unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -313,13 +321,30 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceSpec{
 					CompositionReference: &corev1.ObjectReference{},
 				},
 			},
 			want: want{
 				cmp: &gcmp,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the composition we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceSpec{
+					CompositionReference: &corev1.ObjectReference{},
+				},
+			},
+			want: want{
+				cmp: &gcmpSkipUnstructured,
 			},
 		},
 	}
@@ -1121,7 +1146,15 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gcmp := model.GetComposition(&extv1.Composition{})
+	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "nodes.unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -1208,13 +1241,30 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceClaimSpec{
 					CompositionReference: &corev1.ObjectReference{},
 				},
 			},
 			want: want{
 				cmp: &gcmp,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the composition we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceClaimSpec{
+					CompositionReference: &corev1.ObjectReference{},
+				},
+			},
+			want: want{
+				cmp: &gcmpSkipUnstructured,
 			},
 		},
 	}

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -775,7 +775,15 @@ func TestCompositeResourceSpecConnectionSecret(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gsec := model.GetSecret(&corev1.Secret{})
+	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -862,13 +870,30 @@ func TestCompositeResourceSpecConnectionSecret(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceSpec{
 					WriteConnectionSecretToReference: &xpv1.SecretReference{},
 				},
 			},
 			want: want{
 				sec: &gsec,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the secret we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceSpec{
+					WriteConnectionSecretToReference: &xpv1.SecretReference{},
+				},
+			},
+			want: want{
+				sec: &gsecSkipUnstructured,
 			},
 		},
 	}
@@ -1547,7 +1572,15 @@ func TestCompositeResourceClaimSpecConnectionSecret(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gsec := model.GetSecret(&corev1.Secret{})
+	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -1634,13 +1667,30 @@ func TestCompositeResourceClaimSpecConnectionSecret(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceClaimSpec{
 					WriteConnectionSecretToReference: &xpv1.SecretReference{},
 				},
 			},
 			want: want{
 				sec: &gsec,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the secret we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceClaimSpec{
+					WriteConnectionSecretToReference: &xpv1.SecretReference{},
+				},
+			},
+			want: want{
+				sec: &gsecSkipUnstructured,
 			},
 		},
 	}

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -190,7 +190,7 @@ func (r *configurationRevisionStatus) Objects(ctx context.Context, obj *model.Co
 				continue
 			}
 
-			out.Nodes = append(out.Nodes, model.GetComposition(cmp))
+			out.Nodes = append(out.Nodes, model.GetComposition(cmp, selectedFields))
 			out.TotalCount++
 		}
 	}

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -163,6 +163,7 @@ func (r *configurationRevisionStatus) Objects(ctx context.Context, obj *model.Co
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ObjectRefs)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for _, ref := range obj.ObjectRefs {
 		// Crossplane lints configuration packages to ensure they only contain XRDs and Compositions
@@ -180,7 +181,7 @@ func (r *configurationRevisionStatus) Objects(ctx context.Context, obj *model.Co
 				continue
 			}
 
-			out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd))
+			out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd, selectedFields))
 			out.TotalCount++
 		case extv1.CompositionKind:
 			cmp := &extv1.Composition{}

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -72,6 +72,7 @@ func (r *configuration) Revisions(ctx context.Context, obj *model.Configuration)
 	out := &model.ConfigurationRevisionConnection{
 		Nodes: make([]model.ConfigurationRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		cr := in.Items[i] // So we don't take the address of a range variable.
@@ -83,7 +84,7 @@ func (r *configuration) Revisions(ctx context.Context, obj *model.Configuration)
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&cr))
+		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&cr, selectedFields))
 		out.TotalCount++
 	}
 
@@ -123,7 +124,7 @@ func (r *configuration) ActiveRevision(ctx context.Context, obj *model.Configura
 			continue
 		}
 
-		out := model.GetConfigurationRevision(&cr)
+		out := model.GetConfigurationRevision(&cr, GetSelectedFields(ctx))
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/configuration_test.go
+++ b/internal/graph/resolvers/configuration_test.go
@@ -239,7 +239,7 @@ func TestConfigurationActiveRevision(t *testing.T) {
 		Spec:       pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,

--- a/internal/graph/resolvers/event.go
+++ b/internal/graph/resolvers/event.go
@@ -54,6 +54,7 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (mode
 		graphql.AddError(ctx, errors.Wrap(err, errListEvents))
 		return model.EventConnection{}, nil
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	// If no involved object was supplied we want to fetch all events. This may
 	// include Kubernetes events that don't pertain to Crossplane.
@@ -63,7 +64,7 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (mode
 			TotalCount: len(in.Items),
 		}
 		for i := range in.Items {
-			out.Nodes = append(out.Nodes, model.GetEvent(&in.Items[i]))
+			out.Nodes = append(out.Nodes, model.GetEvent(&in.Items[i], selectedFields))
 		}
 
 		sort.Stable(sort.Reverse(out))
@@ -87,7 +88,7 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (mode
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetEvent(e))
+		out.Nodes = append(out.Nodes, model.GetEvent(e, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/event.go
+++ b/internal/graph/resolvers/event.go
@@ -153,7 +153,7 @@ func (r *event) InvolvedObject(ctx context.Context, obj *model.Event) (model.Kub
 		return nil, nil
 	}
 
-	out, err := model.GetKubernetesResource(u)
+	out, err := model.GetKubernetesResource(u, GetSelectedFields(ctx))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelInvolved))
 		return nil, nil

--- a/internal/graph/resolvers/event_test.go
+++ b/internal/graph/resolvers/event_test.go
@@ -270,7 +270,7 @@ var _ generated.EventResolver = &event{}
 func TestEventInvolvedObject(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{})
+	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/event_test.go
+++ b/internal/graph/resolvers/event_test.go
@@ -324,7 +324,7 @@ var _ generated.EventResolver = &event{}
 func TestEventInvolvedObject(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SelectAll)
+	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -412,7 +412,7 @@ func TestEventInvolvedObject(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/managed.go
+++ b/internal/graph/resolvers/managed.go
@@ -81,6 +81,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 		graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
 		return nil, nil
 	}
+	selectedFields := GetSelectedFields(ctx)
 
 	// We didn't find the CRD we were looking for, list all CRDs and see if we
 	// can find the matching one.
@@ -102,7 +103,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 				continue
 			}
 
-			out := model.GetCustomResourceDefinition(&crd)
+			out := model.GetCustomResourceDefinition(&crd, selectedFields)
 			return &out, nil
 		}
 	}
@@ -110,7 +111,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 	// We found a CRD, let's double check the Group and Kind match our
 	// expectations.
 	if in.GetSpecGroup() == gv.Group && in.GetSpecNames().Kind == obj.Kind {
-		out := model.GetCustomResourceDefinition(in)
+		out := model.GetCustomResourceDefinition(in, selectedFields)
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/managed.go
+++ b/internal/graph/resolvers/managed.go
@@ -147,6 +147,6 @@ func (r *managedResourceSpec) ConnectionSecret(ctx context.Context, obj *model.M
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -59,8 +59,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
+	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured))
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured))
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")
@@ -232,7 +232,6 @@ func TestManagedResourceDefinition(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -58,8 +58,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd)
-	dcrd := model.GetCustomResourceDefinition((crdDifferingPlural))
+	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")

--- a/internal/graph/resolvers/mutation.go
+++ b/internal/graph/resolvers/mutation.go
@@ -102,7 +102,7 @@ func (r *mutation) CreateKubernetesResource(ctx context.Context, input model.Cre
 		return model.CreateKubernetesResourcePayload{}, nil
 	}
 
-	kr, err := model.GetKubernetesResource(u)
+	kr, err := model.GetKubernetesResource(u, GetSelectedFields(ctx).Sub("resource"))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return model.CreateKubernetesResourcePayload{}, nil
@@ -153,7 +153,7 @@ func (r *mutation) UpdateKubernetesResource(ctx context.Context, id model.Refere
 		return model.UpdateKubernetesResourcePayload{}, nil
 	}
 
-	kr, err := model.GetKubernetesResource(u)
+	kr, err := model.GetKubernetesResource(u, GetSelectedFields(ctx).Sub("resource"))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return model.UpdateKubernetesResourcePayload{}, nil
@@ -182,7 +182,7 @@ func (r *mutation) DeleteKubernetesResource(ctx context.Context, id model.Refere
 		return model.DeleteKubernetesResourcePayload{}, nil //nolint:nilerr // IgnoreNotFound appears to trigger this linter.
 	}
 
-	kr, err := model.GetKubernetesResource(u)
+	kr, err := model.GetKubernetesResource(u, GetSelectedFields(ctx).Sub("resource"))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return model.DeleteKubernetesResourcePayload{}, nil

--- a/internal/graph/resolvers/mutation_test.go
+++ b/internal/graph/resolvers/mutation_test.go
@@ -101,7 +101,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u)
+	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
 
 	type args struct {
 		ctx   context.Context
@@ -268,7 +268,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u)
+	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
 
 	type args struct {
 		ctx   context.Context
@@ -444,7 +444,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 	u.SetKind("Example")
 	u.SetName("example")
 
-	kr, _ := model.GetKubernetesResource(u)
+	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
 
 	cases := map[string]struct {
 		reason  string

--- a/internal/graph/resolvers/mutation_test.go
+++ b/internal/graph/resolvers/mutation_test.go
@@ -101,7 +101,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx   context.Context
@@ -246,7 +246,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -268,7 +268,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx   context.Context
@@ -420,7 +420,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -444,7 +444,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 	u.SetKind("Example")
 	u.SetName("example")
 
-	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
 
 	cases := map[string]struct {
 		reason  string
@@ -522,7 +522,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/objectmeta.go
+++ b/internal/graph/resolvers/objectmeta.go
@@ -48,6 +48,7 @@ func (r *objectMeta) Owners(ctx context.Context, obj *model.ObjectMeta) (model.O
 	}
 
 	owners := make([]model.Owner, 0, len(obj.OwnerReferences))
+	selectedFields := GetSelectedFields(ctx).Sub("nodes.resource")
 	for _, ref := range obj.OwnerReferences {
 		u := &kunstructured.Unstructured{}
 		u.SetAPIVersion(ref.APIVersion)
@@ -59,7 +60,7 @@ func (r *objectMeta) Owners(ctx context.Context, obj *model.ObjectMeta) (model.O
 			continue
 		}
 
-		kr, err := model.GetKubernetesResource(u)
+		kr, err := model.GetKubernetesResource(u, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelOwner))
 			continue
@@ -82,6 +83,7 @@ func (r *objectMeta) Controller(ctx context.Context, obj *model.ObjectMeta) (mod
 		return nil, nil
 	}
 
+	selectedFields := GetSelectedFields(ctx)
 	for _, ref := range obj.OwnerReferences {
 		if !pointer.BoolDeref(ref.Controller, false) {
 			continue
@@ -97,7 +99,7 @@ func (r *objectMeta) Controller(ctx context.Context, obj *model.ObjectMeta) (mod
 			return nil, nil
 		}
 
-		kr, err := model.GetKubernetesResource(u)
+		kr, err := model.GetKubernetesResource(u, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelOwner))
 			return nil, nil

--- a/internal/graph/resolvers/objectmeta_test.go
+++ b/internal/graph/resolvers/objectmeta_test.go
@@ -50,7 +50,7 @@ func TestObjectMetaOwners(t *testing.T) {
 	own := unstructured.Unstructured{}
 	own.SetAPIVersion("example.org/v1")
 	own.SetKind("AnOwner")
-	gown, _ := model.GetKubernetesResource(&own)
+	gown, _ := model.GetKubernetesResource(&own, model.SelectAll)
 
 	type args struct {
 		ctx context.Context
@@ -156,7 +156,7 @@ func TestObjectMetaController(t *testing.T) {
 	ctrl := unstructured.Unstructured{}
 	ctrl.SetAPIVersion("example.org/v1")
 	ctrl.SetKind("TheController")
-	gctrl, _ := model.GetKubernetesResource(&ctrl)
+	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SelectAll)
 
 	// An owner
 	own := unstructured.Unstructured{}

--- a/internal/graph/resolvers/objectmeta_test.go
+++ b/internal/graph/resolvers/objectmeta_test.go
@@ -50,7 +50,7 @@ func TestObjectMetaOwners(t *testing.T) {
 	own := unstructured.Unstructured{}
 	own.SetAPIVersion("example.org/v1")
 	own.SetKind("AnOwner")
-	gown, _ := model.GetKubernetesResource(&own, model.SelectAll)
+	gown, _ := model.GetKubernetesResource(&own, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -141,7 +141,6 @@ func TestObjectMetaOwners(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.oc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Owners(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -156,7 +155,7 @@ func TestObjectMetaController(t *testing.T) {
 	ctrl := unstructured.Unstructured{}
 	ctrl.SetAPIVersion("example.org/v1")
 	ctrl.SetKind("TheController")
-	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SelectAll)
+	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SkipFields(model.FieldUnstructured))
 
 	// An owner
 	own := unstructured.Unstructured{}
@@ -286,7 +285,6 @@ func TestObjectMetaController(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.kr, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Controller(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -164,6 +164,7 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ObjectRefs)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for _, ref := range obj.ObjectRefs {
 		// Crossplane lints provider packages to ensure they only contain CRDs,
@@ -182,7 +183,7 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd))
+		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -72,6 +72,7 @@ func (r *provider) Revisions(ctx context.Context, obj *model.Provider) (model.Pr
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
@@ -83,7 +84,7 @@ func (r *provider) Revisions(ctx context.Context, obj *model.Provider) (model.Pr
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr))
+		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr, selectedFields))
 		out.TotalCount++
 	}
 
@@ -108,6 +109,7 @@ func (r *provider) ActiveRevision(ctx context.Context, obj *model.Provider) (*mo
 		return nil, nil
 	}
 
+	selectedFields := GetSelectedFields(ctx)
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
 
@@ -123,7 +125,7 @@ func (r *provider) ActiveRevision(ctx context.Context, obj *model.Provider) (*mo
 			continue
 		}
 
-		out := model.GetProviderRevision(&pr)
+		out := model.GetProviderRevision(&pr, selectedFields)
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -72,7 +72,7 @@ func (r *provider) Revisions(ctx context.Context, obj *model.Provider) (model.Pr
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -385,7 +385,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{})
+	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -62,7 +62,7 @@ func TestProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields("unstructured"))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -73,7 +73,7 @@ func TestProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetProviderRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields("unstructured"))
+	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision which we do not control.
 	other := pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "not-ours"}}
@@ -81,9 +81,9 @@ func TestProviderRevisions(t *testing.T) {
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
-			Name: "nodes",
+			Name: model.FieldNodes,
 			SelectionSet: ast.SelectionSet{
-				&ast.Field{Name: "unstructured"},
+				&ast.Field{Name: model.FieldUnstructured},
 			},
 		},
 	}
@@ -222,7 +222,7 @@ func TestProviderActiveRevision(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields("unstructured"))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -239,10 +239,10 @@ func TestProviderActiveRevision(t *testing.T) {
 		Spec:       pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 
-	// A selection set with "unstructured" field included.
+	// A selection set with fieldUnstructured field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
-			Name: "unstructured",
+			Name: model.FieldUnstructured,
 		},
 	}
 

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -385,7 +385,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SelectAll)
+	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -515,7 +515,6 @@ func TestProviderRevisionStatusObjects(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.krc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/providerconfig.go
+++ b/internal/graph/resolvers/providerconfig.go
@@ -101,7 +101,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 				continue
 			}
 
-			out := model.GetCustomResourceDefinition(&crd)
+			out := model.GetCustomResourceDefinition(&crd, GetSelectedFields(ctx))
 			return &out, nil
 		}
 	}
@@ -109,7 +109,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 	// We found a CRD, let's double check the Group and Kind match our
 	// expectations.
 	if in.GetSpecGroup() == gv.Group && in.GetSpecNames().Kind == obj.Kind {
-		out := model.GetCustomResourceDefinition(in)
+		out := model.GetCustomResourceDefinition(in, GetSelectedFields(ctx))
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -56,8 +56,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
+	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured))
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured))
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")
@@ -229,7 +229,6 @@ func TestProviderConfigDefinition(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -56,8 +56,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd)
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural)
+	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -384,9 +384,10 @@ func (r *query) Configurations(ctx context.Context) (model.ConfigurationConnecti
 		Nodes:      make([]model.Configuration, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
-		out.Nodes = append(out.Nodes, model.GetConfiguration(&in.Items[i]))
+		out.Nodes = append(out.Nodes, model.GetConfiguration(&in.Items[i], selectedFields))
 	}
 
 	sort.Stable(out)

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -500,6 +500,7 @@ func (r *query) Compositions(ctx context.Context, revision *model.ReferenceID, d
 	out := &model.CompositionConnection{
 		Nodes: make([]model.Composition, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		cmp := &in.Items[i]
@@ -514,7 +515,7 @@ func (r *query) Compositions(ctx context.Context, revision *model.ReferenceID, d
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetComposition(cmp))
+		out.Nodes = append(out.Nodes, model.GetComposition(cmp, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -135,7 +135,7 @@ func (r *query) KubernetesResource(ctx context.Context, id model.ReferenceID) (m
 		return nil, nil
 	}
 
-	out, err := model.GetKubernetesResource(u)
+	out, err := model.GetKubernetesResource(u, GetSelectedFields(ctx))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return nil, nil
@@ -176,9 +176,10 @@ func (r *query) KubernetesResources(ctx context.Context, apiVersion, kind string
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(in.Items)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
-		kr, err := model.GetKubernetesResource(&in.Items[i])
+		kr, err := model.GetKubernetesResource(&in.Items[i], selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 			continue
@@ -301,6 +302,7 @@ func (r *query) ProviderRevisions(ctx context.Context, provider *model.Reference
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
@@ -315,7 +317,7 @@ func (r *query) ProviderRevisions(ctx context.Context, provider *model.Reference
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr))
+		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -248,7 +248,7 @@ func (r *query) ConfigMap(ctx context.Context, namespace, name string) (*model.C
 		return nil, nil
 	}
 
-	out := model.GetConfigMap(cm)
+	out := model.GetConfigMap(cm, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -176,7 +176,7 @@ func (r *query) KubernetesResources(ctx context.Context, apiVersion, kind string
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(in.Items)),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		kr, err := model.GetKubernetesResource(&in.Items[i], selectedFields)
@@ -302,7 +302,7 @@ func (r *query) ProviderRevisions(ctx context.Context, provider *model.Reference
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -226,7 +226,7 @@ func (r *query) Secret(ctx context.Context, namespace, name string) (*model.Secr
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -17,6 +17,7 @@ package resolvers
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ type query struct {
 }
 
 // Recursively collect `CrossplaneResourceTreeNode`s from the given KubernetesResource
-func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResource, parentID *model.ReferenceID) ([]model.CrossplaneResourceTreeNode, error) { //nolint:gocyclo
+func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResource, parentID *model.ReferenceID) []model.CrossplaneResourceTreeNode { //nolint:gocyclo
 	// This isn't _really_ that complex; it's a long but simple switch.
 
 	switch typedRes := res.(type) {
@@ -63,19 +64,32 @@ func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResour
 			GetSelectedFields(ctx).Sub("nodes.resource").Pre(model.FieldNodes),
 		), &typedRes.Spec)
 		if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-			return nil, err
+			return nil
 		}
 
-		for _, childRes := range resources.Nodes {
-			childList, err := r.getAllDescendant(ctx, childRes, &typedRes.ID)
-			if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-				return nil, err
-			}
+		// Collect all concurrently.
+		var (
+			wg sync.WaitGroup
+		)
+		childLists := make([][]model.CrossplaneResourceTreeNode, len(resources.Nodes))
+		for i, childRes := range resources.Nodes {
+			i, childRes := i, childRes // So we don't capture the loop variable.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				childLists[i] = r.getAllDescendant(ctx, childRes, &typedRes.ID)
+			}()
+		}
+		wg.Wait()
 
+		if len(graphql.GetErrors(ctx)) > 0 {
+			return nil
+		}
+
+		for _, childList := range childLists {
 			list = append(list, childList...)
 		}
-
-		return list, nil
+		return list
 	case model.CompositeResourceClaim:
 		list := []model.CrossplaneResourceTreeNode{{ParentID: parentID, Resource: typedRes}}
 
@@ -84,21 +98,21 @@ func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResour
 			GetSelectedFields(ctx).Sub("nodes.resource"),
 		), &typedRes.Spec)
 		if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-			return nil, err
+			return nil
 		}
 
 		if composite == nil {
-			return list, nil
+			return list
 		}
 
-		childList, err := r.getAllDescendant(ctx, *composite, &typedRes.ID)
+		childList := r.getAllDescendant(ctx, *composite, &typedRes.ID)
 		if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-			return nil, err
+			return nil
 		}
 
-		return append(list, childList...), nil
+		return append(list, childList...)
 	default:
-		return []model.CrossplaneResourceTreeNode{{ParentID: parentID, Resource: typedRes}}, nil
+		return []model.CrossplaneResourceTreeNode{{ParentID: parentID, Resource: typedRes}}
 	}
 }
 
@@ -116,9 +130,9 @@ func (r *query) CrossplaneResourceTree(ctx context.Context, id model.ReferenceID
 		return model.CrossplaneResourceTreeConnection{}, err
 	}
 
-	list, err := r.getAllDescendant(ctx, rootRes, nil)
-	if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-		return model.CrossplaneResourceTreeConnection{}, err
+	list := r.getAllDescendant(ctx, rootRes, nil)
+	if len(graphql.GetErrors(ctx)) > 0 {
+		return model.CrossplaneResourceTreeConnection{}, nil
 	}
 
 	return model.CrossplaneResourceTreeConnection{Nodes: list, TotalCount: len(list)}, nil

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -457,6 +457,7 @@ func (r *query) CompositeResourceDefinitions(ctx context.Context, revision *mode
 	out := &model.CompositeResourceDefinitionConnection{
 		Nodes: make([]model.CompositeResourceDefinition, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		xrd := &in.Items[i]
@@ -471,7 +472,7 @@ func (r *query) CompositeResourceDefinitions(ctx context.Context, revision *mode
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd))
+		out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -346,6 +346,7 @@ func (r *query) CustomResourceDefinitions(ctx context.Context, revision *model.R
 	out := &model.CustomResourceDefinitionConnection{
 		Nodes: make([]model.CustomResourceDefinition, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		xrd := &xunstructured.CustomResourceDefinition{Unstructured: in.Items[i]}
@@ -355,7 +356,7 @@ func (r *query) CustomResourceDefinitions(ctx context.Context, revision *model.R
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(xrd))
+		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(xrd, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -414,6 +414,7 @@ func (r *query) ConfigurationRevisions(ctx context.Context, configuration *model
 	out := &model.ConfigurationRevisionConnection{
 		Nodes: make([]model.ConfigurationRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
@@ -428,7 +429,7 @@ func (r *query) ConfigurationRevisions(ctx context.Context, configuration *model
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&pr))
+		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&pr, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -273,9 +273,10 @@ func (r *query) Providers(ctx context.Context) (model.ProviderConnection, error)
 		Nodes:      make([]model.Provider, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
-		out.Nodes = append(out.Nodes, model.GetProvider(&in.Items[i]))
+		out.Nodes = append(out.Nodes, model.GetProvider(&in.Items[i], selectedFields))
 	}
 
 	sort.Stable(out)

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -809,7 +809,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields("unstructured"))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -824,7 +824,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetProviderRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields("unstructured"))
+	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision which we do not control.
 	other := pkgv1.ProviderRevision{
@@ -838,15 +838,15 @@ func TestQueryProviderRevisions(t *testing.T) {
 		},
 	}
 	gother := model.GetProviderRevision(&other, model.SelectAll)
-	gotherSkipUnstructured := model.GetProviderRevision(&other, model.SkipFields("unstructured"))
+	gotherSkipUnstructured := model.GetProviderRevision(&other, model.SkipFields(model.FieldUnstructured))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
-			Name: "nodes",
+			Name: model.FieldNodes,
 			SelectionSet: ast.SelectionSet{
 				&ast.Field{
-					Name: "unstructured",
+					Name: model.FieldUnstructured,
 				},
 			},
 		},

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -221,10 +221,7 @@ func TestCrossplaneResourceTree(t *testing.T) {
 			}
 
 			diffOptions := []cmp.Option{
-				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.ManagedResource{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.ProviderConfig{}, "Unstructured"),
+
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
 			}
 
@@ -238,7 +235,7 @@ func TestCrossplaneResourceTree(t *testing.T) {
 func TestQueryKubernetesResource(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gkr, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SelectAll)
+	gkr, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -317,7 +314,7 @@ func TestQueryKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1309,12 +1306,12 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 		},
 	})
 
-	gowned := model.GetCustomResourceDefinition(owned, model.SelectAll)
+	gowned := model.GetCustomResourceDefinition(owned, model.SkipFields(model.FieldUnstructured))
 
 	dangler := xunstructured.NewCRD()
 	dangler.SetName("coolconfig")
 
-	gdangler := model.GetCustomResourceDefinition(dangler, model.SelectAll)
+	gdangler := model.GetCustomResourceDefinition(dangler, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx      context.Context
@@ -1437,7 +1434,6 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.xrdc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -1154,12 +1154,12 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 		},
 	})
 
-	gowned := model.GetCustomResourceDefinition(owned)
+	gowned := model.GetCustomResourceDefinition(owned, model.SelectAll)
 
 	dangler := xunstructured.NewCRD()
 	dangler.SetName("coolconfig")
 
-	gdangler := model.GetCustomResourceDefinition(dangler)
+	gdangler := model.GetCustomResourceDefinition(dangler, model.SelectAll)
 
 	type args struct {
 		ctx      context.Context

--- a/internal/graph/resolvers/selection.go
+++ b/internal/graph/resolvers/selection.go
@@ -1,0 +1,74 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+// SelectedFields is a set of selected fields.
+type SelectedFields map[string]struct{}
+
+// Has returns true if the field is selected.
+func (s SelectedFields) Has(path string) bool {
+	_, ok := s[path]
+	return ok
+}
+
+func (s SelectedFields) Sub(prefix string) SelectedFields {
+	if len(s) == 0 {
+		return nil
+	}
+	sub := SelectedFields{}
+	for k := range s {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix && k[len(prefix)] == '.' {
+			sub[k[len(prefix)+1:]] = struct{}{}
+		}
+	}
+	return sub
+}
+
+func GetSelectedFields(ctx context.Context) SelectedFields {
+	resctx := graphql.GetFieldContext(ctx)
+	if resctx == nil { // not in a resolver context
+		return nil
+	}
+
+	selection := SelectedFields{}
+	collectSelectedFields(
+		graphql.GetOperationContext(ctx),
+		selection,
+		graphql.CollectFields(graphql.GetOperationContext(ctx), resctx.Field.Selections, nil),
+		"",
+	)
+	return selection
+}
+
+func collectSelectedFields(ctx *graphql.OperationContext, selection SelectedFields, fields []graphql.CollectedField, prefix string) {
+	for _, column := range fields {
+		prefixColumn := fieldPath(prefix, column.Name)
+		selection[prefixColumn] = struct{}{}
+		collectSelectedFields(ctx, selection, graphql.CollectFields(ctx, column.Selections, nil), prefixColumn)
+	}
+}
+
+func fieldPath(prefix, name string) string {
+	if len(prefix) > 0 {
+		return prefix + "." + name
+	}
+	return name
+}


### PR DESCRIPTION
- filtering on selected fields
- remove unused method
- parallelize looping resolvers

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This is the next PR before introducing `fieldPath` partial selection to deprecate
the `unstructured` field.

Using gqlgen field collection API we can check if the `unstructured` field has
been requested before generating json in memory.

Additionally, I've parallelized recursive resolvers, this is especially visible
when loading console for the first time.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
I tested this locally and by installing this image on a running MCP.

