### PR TITLE
fieldPath field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/epk/smaz v0.0.0-20220720222521-c11a89997fcf
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-chi/chi/v5 v5.0.3
-	github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929
 	github.com/google/addlicense v0.0.0-20210428195630-6d92264d7170
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
@@ -91,7 +90,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
-	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,6 @@ github.com/go-chi/chi/v5 v5.0.3/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITL
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929 h1:GdbUZo0+623j+pKRhwwdf1q28IUgRc7asx3TjF9b7VQ=
-github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929/go.mod h1:AHV+bpNGVGD0DCHMBhhTYtT7yeBYD9Yk92XAjB7vOgo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -812,8 +810,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -19,7 +19,7 @@
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
 // Generate xgql models, bindings, etc per gqlgen.yaml.
-//go:generate go run -tags generate github.com/99designs/gqlgen
+//go:generate go run -tags generate ./graph/generate/gqlgen
 
 // Add license headers to all files.
 //go:generate go run -tags generate github.com/google/addlicense -v -c "Upbound Inc" . ../cmd

--- a/internal/graph/generate/gqlgen/main.go
+++ b/internal/graph/generate/gqlgen/main.go
@@ -1,0 +1,112 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build generate
+// +build generate
+
+package main
+
+import (
+	"fmt"
+	"go/types"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/99designs/gqlgen/api"
+	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/plugin/modelgen"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// importType imports a type from a string reference.
+func importType(typeRef string) types.Type {
+	if typeRef[0] == '*' {
+		return types.NewPointer(importType(typeRef[1:]))
+	}
+	if strings.HasPrefix(typeRef, "[]") {
+		return types.NewSlice(importType(typeRef[2:]))
+	}
+
+	typeSep := strings.LastIndex(typeRef, ".")
+	if typeSep == -1 { // builtinType
+		return types.Universe.Lookup(typeRef).Type()
+	}
+
+	// typeName is <pkg>.<typeName>
+	pkgPath := typeRef[:typeSep]
+	typeRef = typeRef[typeSep+1:]
+
+	// pkgPath is <pkgPath...>/<pkgName>
+	pkgName := pkgPath
+	if pathSep := strings.LastIndex(pkgPath, "/"); pathSep != -1 {
+		pkgName = pkgPath[pathSep+1:]
+	}
+
+	pkg := types.NewPackage(pkgPath, pkgName)
+	// gqlgen doesn't use some of the fields, so we leave them 0/nil
+	return types.NewNamed(types.NewTypeName(0, pkg, typeRef, nil), nil, nil)
+
+}
+
+// goTypeFieldHook is a mutation function for modelgen plugin.
+// It extends gqlgens `goField` directive to allow overriding field type make the field embedded.
+//
+// For a brief explanation of Field Mutate Hooks read [GQLGen Recipes].
+//
+// [GQLGen Recipes]: https://gqlgen.com/recipes/modelgen-hook/#fieldmutatehook
+func goTypeFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *modelgen.Field) (*modelgen.Field, error) {
+	// Call default hook to proceed standard directives like goField and goTag.
+	// You can omit it, if you don't need.
+	if f, err := modelgen.DefaultFieldMutateHook(td, fd, f); err != nil {
+		return f, err
+	}
+
+	c := fd.Directives.ForName("goField")
+	if c != nil {
+		if typeRef := c.Arguments.ForName("type"); typeRef != nil {
+			f.Type = importType(typeRef.Value.Raw)
+		}
+		if embed := c.Arguments.ForName("embed"); embed != nil {
+			if do, err := embed.Value.Value(nil); err == nil && do.(bool) {
+				f.GoName = ""
+			}
+		}
+	}
+
+	return f, nil
+}
+
+func main() {
+	// Disable log output from gqlgen.
+	log.SetOutput(io.Discard)
+	cfg, err := config.LoadConfigFromDefaultLocations()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to load config", err.Error())
+		os.Exit(2)
+	}
+
+	// Attaching the mutation function onto modelgen plugin
+	p := modelgen.Plugin{
+		FieldHook: goTypeFieldHook,
+	}
+
+	err = api.Generate(cfg, api.ReplacePlugin(&p))
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(3)
+	}
+}

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -71,6 +71,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -83,6 +84,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -131,6 +133,7 @@ type ComplexityRoot struct {
 		DefinedCompositeResourceClaims func(childComplexity int, version *string, namespace *string, options *model.DefinedCompositeResourceClaimOptionsInput) int
 		DefinedCompositeResources      func(childComplexity int, version *string, options *model.DefinedCompositeResourceOptionsInput) int
 		Events                         func(childComplexity int) int
+		FieldPath                      func(childComplexity int, path *string) int
 		ID                             func(childComplexity int) int
 		Kind                           func(childComplexity int) int
 		Metadata                       func(childComplexity int) int
@@ -203,6 +206,7 @@ type ComplexityRoot struct {
 	Composition struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -237,6 +241,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Data         func(childComplexity int, keys []string) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -247,6 +252,7 @@ type ComplexityRoot struct {
 		APIVersion     func(childComplexity int) int
 		ActiveRevision func(childComplexity int) int
 		Events         func(childComplexity int) int
+		FieldPath      func(childComplexity int, path *string) int
 		ID             func(childComplexity int) int
 		Kind           func(childComplexity int) int
 		Metadata       func(childComplexity int) int
@@ -264,6 +270,7 @@ type ComplexityRoot struct {
 	ConfigurationRevision struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -328,6 +335,7 @@ type ComplexityRoot struct {
 		APIVersion       func(childComplexity int) int
 		DefinedResources func(childComplexity int, version *string) int
 		Events           func(childComplexity int) int
+		FieldPath        func(childComplexity int, path *string) int
 		ID               func(childComplexity int) int
 		Kind             func(childComplexity int) int
 		Metadata         func(childComplexity int) int
@@ -378,6 +386,7 @@ type ComplexityRoot struct {
 	Event struct {
 		APIVersion     func(childComplexity int) int
 		Count          func(childComplexity int) int
+		FieldPath      func(childComplexity int, path *string) int
 		FirstTime      func(childComplexity int) int
 		ID             func(childComplexity int) int
 		InvolvedObject func(childComplexity int) int
@@ -403,6 +412,7 @@ type ComplexityRoot struct {
 	GenericResource struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -426,6 +436,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -493,6 +504,7 @@ type ComplexityRoot struct {
 		APIVersion     func(childComplexity int) int
 		ActiveRevision func(childComplexity int) int
 		Events         func(childComplexity int) int
+		FieldPath      func(childComplexity int, path *string) int
 		ID             func(childComplexity int) int
 		Kind           func(childComplexity int) int
 		Metadata       func(childComplexity int) int
@@ -506,6 +518,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -530,6 +543,7 @@ type ComplexityRoot struct {
 	ProviderRevision struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -596,6 +610,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Data         func(childComplexity int, keys []string) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -769,6 +784,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CompositeResource.Events(childComplexity), true
 
+	case "CompositeResource.fieldPath":
+		if e.complexity.CompositeResource.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CompositeResource_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CompositeResource.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "CompositeResource.id":
 		if e.complexity.CompositeResource.ID == nil {
 			break
@@ -831,6 +858,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CompositeResourceClaim.Events(childComplexity), true
+
+	case "CompositeResourceClaim.fieldPath":
+		if e.complexity.CompositeResourceClaim.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CompositeResourceClaim_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CompositeResourceClaim.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "CompositeResourceClaim.id":
 		if e.complexity.CompositeResourceClaim.ID == nil {
@@ -1030,6 +1069,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CompositeResourceDefinition.Events(childComplexity), true
+
+	case "CompositeResourceDefinition.fieldPath":
+		if e.complexity.CompositeResourceDefinition.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CompositeResourceDefinition_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CompositeResourceDefinition.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "CompositeResourceDefinition.id":
 		if e.complexity.CompositeResourceDefinition.ID == nil {
@@ -1325,6 +1376,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Composition.Events(childComplexity), true
 
+	case "Composition.fieldPath":
+		if e.complexity.Composition.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Composition_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Composition.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Composition.id":
 		if e.complexity.Composition.ID == nil {
 			break
@@ -1463,6 +1526,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ConfigMap.Events(childComplexity), true
 
+	case "ConfigMap.fieldPath":
+		if e.complexity.ConfigMap.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ConfigMap_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ConfigMap.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "ConfigMap.id":
 		if e.complexity.ConfigMap.ID == nil {
 			break
@@ -1511,6 +1586,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Configuration.Events(childComplexity), true
+
+	case "Configuration.fieldPath":
+		if e.complexity.Configuration.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Configuration_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Configuration.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "Configuration.id":
 		if e.complexity.Configuration.ID == nil {
@@ -1588,6 +1675,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ConfigurationRevision.Events(childComplexity), true
+
+	case "ConfigurationRevision.fieldPath":
+		if e.complexity.ConfigurationRevision.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ConfigurationRevision_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ConfigurationRevision.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ConfigurationRevision.id":
 		if e.complexity.ConfigurationRevision.ID == nil {
@@ -1853,6 +1952,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CustomResourceDefinition.Events(childComplexity), true
 
+	case "CustomResourceDefinition.fieldPath":
+		if e.complexity.CustomResourceDefinition.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CustomResourceDefinition_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CustomResourceDefinition.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "CustomResourceDefinition.id":
 		if e.complexity.CustomResourceDefinition.ID == nil {
 			break
@@ -2035,6 +2146,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Event.Count(childComplexity), true
 
+	case "Event.fieldPath":
+		if e.complexity.Event.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Event_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Event.firstTime":
 		if e.complexity.Event.FirstTime == nil {
 			break
@@ -2147,6 +2270,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.GenericResource.Events(childComplexity), true
 
+	case "GenericResource.fieldPath":
+		if e.complexity.GenericResource.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_GenericResource_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.GenericResource.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "GenericResource.id":
 		if e.complexity.GenericResource.ID == nil {
 			break
@@ -2223,6 +2358,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ManagedResource.Events(childComplexity), true
+
+	case "ManagedResource.fieldPath":
+		if e.complexity.ManagedResource.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ManagedResource_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ManagedResource.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ManagedResource.id":
 		if e.complexity.ManagedResource.ID == nil {
@@ -2529,6 +2676,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Provider.Events(childComplexity), true
 
+	case "Provider.fieldPath":
+		if e.complexity.Provider.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Provider_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Provider.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Provider.id":
 		if e.complexity.Provider.ID == nil {
 			break
@@ -2598,6 +2757,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProviderConfig.Events(childComplexity), true
+
+	case "ProviderConfig.fieldPath":
+		if e.complexity.ProviderConfig.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ProviderConfig_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ProviderConfig.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ProviderConfig.id":
 		if e.complexity.ProviderConfig.ID == nil {
@@ -2682,6 +2853,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProviderRevision.Events(childComplexity), true
+
+	case "ProviderRevision.fieldPath":
+		if e.complexity.ProviderRevision.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ProviderRevision_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ProviderRevision.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ProviderRevision.id":
 		if e.complexity.ProviderRevision.ID == nil {
@@ -3058,6 +3241,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Secret.Events(childComplexity), true
 
+	case "Secret.fieldPath":
+		if e.complexity.Secret.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Secret_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Secret.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Secret.id":
 		if e.complexity.Secret.ID == nil {
 			break
@@ -3263,6 +3458,91 @@ type CompositeResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -3580,6 +3860,91 @@ type Composition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -3658,6 +4023,91 @@ interface KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection!
@@ -3705,6 +4155,91 @@ type GenericResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -3974,6 +4509,91 @@ type Event implements Node {
 
   "An unstructured JSON representation of the event."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 }
 
 """
@@ -4036,6 +4656,91 @@ type Secret implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   """
   Events pertaining to this resource.
@@ -4077,6 +4782,91 @@ type ConfigMap implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   # TODO(negz): Support binaryData too? What would the return value be?
 
@@ -4141,6 +4931,91 @@ type CustomResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4313,6 +5188,91 @@ type CompositeResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4415,6 +5375,91 @@ type CompositeResourceClaim implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4511,6 +5556,91 @@ type Configuration implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4629,6 +5759,91 @@ type ConfigurationRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4726,6 +5941,8 @@ directive @goField(
   forceResolver: Boolean
   name: String
   omittable: Boolean
+  type: String
+  embed: Boolean
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goTag(
@@ -4759,6 +5976,91 @@ type ManagedResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5017,6 +6319,91 @@ type Provider implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5134,6 +6521,91 @@ type ProviderRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5243,6 +6715,91 @@ type ProviderConfig implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5530,6 +7087,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 
 // region    ***************************** args.gotpl *****************************
 
+func (ec *executionContext) field_CompositeResourceClaim_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_CompositeResourceDefinition_definedCompositeResourceClaims_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -5587,6 +7159,51 @@ func (ec *executionContext) field_CompositeResourceDefinition_definedCompositeRe
 	return args, nil
 }
 
+func (ec *executionContext) field_CompositeResourceDefinition_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_CompositeResource_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Composition_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_ConfigMap_data_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -5602,6 +7219,51 @@ func (ec *executionContext) field_ConfigMap_data_args(ctx context.Context, rawAr
 	return args, nil
 }
 
+func (ec *executionContext) field_ConfigMap_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ConfigurationRevision_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Configuration_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_CustomResourceDefinition_definedResources_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -5614,6 +7276,66 @@ func (ec *executionContext) field_CustomResourceDefinition_definedResources_args
 		}
 	}
 	args["version"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_CustomResourceDefinition_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Event_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_GenericResource_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ManagedResource_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
 	return args, nil
 }
 
@@ -5698,6 +7420,51 @@ func (ec *executionContext) field_ObjectMeta_labels_args(ctx context.Context, ra
 		}
 	}
 	args["keys"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ProviderConfig_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ProviderRevision_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Provider_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
 	return args, nil
 }
 
@@ -5974,6 +7741,21 @@ func (ec *executionContext) field_Secret_data_args(ctx context.Context, rawArgs 
 		}
 	}
 	args["keys"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Secret_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
 	return args, nil
 }
 
@@ -6340,7 +8122,7 @@ func (ec *executionContext) _CompositeResource_unstructured(ctx context.Context,
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6361,11 +8143,66 @@ func (ec *executionContext) fieldContext_CompositeResource_unstructured(ctx cont
 	fc = &graphql.FieldContext{
 		Object:     "CompositeResource",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompositeResource_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompositeResource_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompositeResource_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompositeResource",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CompositeResource_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -6470,6 +8307,8 @@ func (ec *executionContext) fieldContext_CompositeResource_definition(ctx contex
 				return ec.fieldContext_CompositeResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceDefinition_events(ctx, field)
 			case "compositeResourceCRD":
@@ -6810,7 +8649,7 @@ func (ec *executionContext) _CompositeResourceClaim_unstructured(ctx context.Con
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6831,11 +8670,66 @@ func (ec *executionContext) fieldContext_CompositeResourceClaim_unstructured(ctx
 	fc = &graphql.FieldContext{
 		Object:     "CompositeResourceClaim",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompositeResourceClaim_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceClaim) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompositeResourceClaim_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompositeResourceClaim_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompositeResourceClaim",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CompositeResourceClaim_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -6940,6 +8834,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaim_definition(ctx c
 				return ec.fieldContext_CompositeResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceDefinition_events(ctx, field)
 			case "compositeResourceCRD":
@@ -7007,6 +8903,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimConnection_nodes(
 				return ec.fieldContext_CompositeResourceClaim_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceClaim_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceClaim_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceClaim_events(ctx, field)
 			case "definition":
@@ -7153,6 +9051,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimSpec_composition(
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -7302,6 +9202,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimSpec_resource(ctx
 				return ec.fieldContext_CompositeResource_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResource_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResource_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResource_events(ctx, field)
 			case "definition":
@@ -7412,6 +9314,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimSpec_connectionSe
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -7616,6 +9520,8 @@ func (ec *executionContext) fieldContext_CompositeResourceConnection_nodes(ctx c
 				return ec.fieldContext_CompositeResource_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResource_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResource_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResource_events(ctx, field)
 			case "definition":
@@ -8035,7 +9941,7 @@ func (ec *executionContext) _CompositeResourceDefinition_unstructured(ctx contex
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8056,11 +9962,66 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinition_unstructure
 	fc = &graphql.FieldContext{
 		Object:     "CompositeResourceDefinition",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompositeResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompositeResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompositeResourceDefinition",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CompositeResourceDefinition_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -8165,6 +10126,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinition_compositeRe
 				return ec.fieldContext_CustomResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CustomResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CustomResourceDefinition_events(ctx, field)
 			case "definedResources":
@@ -8226,6 +10189,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinition_compositeRe
 				return ec.fieldContext_CustomResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CustomResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CustomResourceDefinition_events(ctx, field)
 			case "definedResources":
@@ -8409,6 +10374,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinitionConnection_n
 				return ec.fieldContext_CompositeResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceDefinition_events(ctx, field)
 			case "compositeResourceCRD":
@@ -9064,6 +11031,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinitionSpec_default
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -9123,6 +11092,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinitionSpec_enforce
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -9510,6 +11481,8 @@ func (ec *executionContext) fieldContext_CompositeResourceSpec_composition(ctx c
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -9659,6 +11632,8 @@ func (ec *executionContext) fieldContext_CompositeResourceSpec_claim(ctx context
 				return ec.fieldContext_CompositeResourceClaim_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceClaim_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceClaim_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceClaim_events(ctx, field)
 			case "definition":
@@ -9769,6 +11744,8 @@ func (ec *executionContext) fieldContext_CompositeResourceSpec_connectionSecret(
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -10325,7 +12302,7 @@ func (ec *executionContext) _Composition_unstructured(ctx context.Context, field
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10346,11 +12323,66 @@ func (ec *executionContext) fieldContext_Composition_unstructured(ctx context.Co
 	fc = &graphql.FieldContext{
 		Object:     "Composition",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Composition_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Composition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Composition_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Composition_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Composition",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Composition_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -10455,6 +12487,8 @@ func (ec *executionContext) fieldContext_CompositionConnection_nodes(ctx context
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -11137,7 +13171,7 @@ func (ec *executionContext) _ConfigMap_unstructured(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -11158,11 +13192,66 @@ func (ec *executionContext) fieldContext_ConfigMap_unstructured(ctx context.Cont
 	fc = &graphql.FieldContext{
 		Object:     "ConfigMap",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConfigMap_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ConfigMap) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConfigMap_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConfigMap_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConfigMap",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ConfigMap_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -11540,7 +13629,7 @@ func (ec *executionContext) _Configuration_unstructured(ctx context.Context, fie
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -11561,11 +13650,66 @@ func (ec *executionContext) fieldContext_Configuration_unstructured(ctx context.
 	fc = &graphql.FieldContext{
 		Object:     "Configuration",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Configuration_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Configuration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Configuration_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Configuration_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Configuration",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Configuration_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -11720,6 +13864,8 @@ func (ec *executionContext) fieldContext_Configuration_activeRevision(ctx contex
 				return ec.fieldContext_ConfigurationRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ConfigurationRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ConfigurationRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ConfigurationRevision_events(ctx, field)
 			}
@@ -11779,6 +13925,8 @@ func (ec *executionContext) fieldContext_ConfigurationConnection_nodes(ctx conte
 				return ec.fieldContext_Configuration_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Configuration_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Configuration_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Configuration_events(ctx, field)
 			case "revisions":
@@ -12165,7 +14313,7 @@ func (ec *executionContext) _ConfigurationRevision_unstructured(ctx context.Cont
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -12186,11 +14334,66 @@ func (ec *executionContext) fieldContext_ConfigurationRevision_unstructured(ctx 
 	fc = &graphql.FieldContext{
 		Object:     "ConfigurationRevision",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConfigurationRevision_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ConfigurationRevision) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConfigurationRevision_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConfigurationRevision_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConfigurationRevision",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ConfigurationRevision_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -12295,6 +14498,8 @@ func (ec *executionContext) fieldContext_ConfigurationRevisionConnection_nodes(c
 				return ec.fieldContext_ConfigurationRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ConfigurationRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ConfigurationRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ConfigurationRevision_events(ctx, field)
 			}
@@ -13798,7 +16003,7 @@ func (ec *executionContext) _CustomResourceDefinition_unstructured(ctx context.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -13819,11 +16024,66 @@ func (ec *executionContext) fieldContext_CustomResourceDefinition_unstructured(c
 	fc = &graphql.FieldContext{
 		Object:     "CustomResourceDefinition",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CustomResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CustomResourceDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CustomResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CustomResourceDefinition",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CustomResourceDefinition_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -13989,6 +16249,8 @@ func (ec *executionContext) fieldContext_CustomResourceDefinitionConnection_node
 				return ec.fieldContext_CustomResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CustomResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CustomResourceDefinition_events(ctx, field)
 			case "definedResources":
@@ -15310,7 +17572,7 @@ func (ec *executionContext) _Event_unstructured(ctx context.Context, field graph
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15331,11 +17593,66 @@ func (ec *executionContext) fieldContext_Event_unstructured(ctx context.Context,
 	fc = &graphql.FieldContext{
 		Object:     "Event",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Event_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Event) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Event_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Event_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Event",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Event_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -15402,6 +17719,8 @@ func (ec *executionContext) fieldContext_EventConnection_nodes(ctx context.Conte
 				return ec.fieldContext_Event_lastTime(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Event_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Event_fieldPath(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Event", field.Name)
 		},
@@ -15710,7 +18029,7 @@ func (ec *executionContext) _GenericResource_unstructured(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15731,11 +18050,66 @@ func (ec *executionContext) fieldContext_GenericResource_unstructured(ctx contex
 	fc = &graphql.FieldContext{
 		Object:     "GenericResource",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GenericResource_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.GenericResource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GenericResource_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GenericResource_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GenericResource",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_GenericResource_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -16273,7 +18647,7 @@ func (ec *executionContext) _ManagedResource_unstructured(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -16294,11 +18668,66 @@ func (ec *executionContext) fieldContext_ManagedResource_unstructured(ctx contex
 	fc = &graphql.FieldContext{
 		Object:     "ManagedResource",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ManagedResource_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ManagedResource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ManagedResource_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ManagedResource_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ManagedResource",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ManagedResource_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -16444,6 +18873,8 @@ func (ec *executionContext) fieldContext_ManagedResourceSpec_connectionSecret(ct
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -18137,7 +20568,7 @@ func (ec *executionContext) _Provider_unstructured(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -18158,11 +20589,66 @@ func (ec *executionContext) fieldContext_Provider_unstructured(ctx context.Conte
 	fc = &graphql.FieldContext{
 		Object:     "Provider",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Provider_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Provider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Provider_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Provider_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Provider",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Provider_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -18317,6 +20803,8 @@ func (ec *executionContext) fieldContext_Provider_activeRevision(ctx context.Con
 				return ec.fieldContext_ProviderRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ProviderRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ProviderRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ProviderRevision_events(ctx, field)
 			}
@@ -18589,7 +21077,7 @@ func (ec *executionContext) _ProviderConfig_unstructured(ctx context.Context, fi
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -18610,11 +21098,66 @@ func (ec *executionContext) fieldContext_ProviderConfig_unstructured(ctx context
 	fc = &graphql.FieldContext{
 		Object:     "ProviderConfig",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProviderConfig_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ProviderConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProviderConfig_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProviderConfig_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProviderConfig",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ProviderConfig_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -18898,6 +21441,8 @@ func (ec *executionContext) fieldContext_ProviderConnection_nodes(ctx context.Co
 				return ec.fieldContext_Provider_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Provider_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Provider_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Provider_events(ctx, field)
 			case "revisions":
@@ -19284,7 +21829,7 @@ func (ec *executionContext) _ProviderRevision_unstructured(ctx context.Context, 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -19305,11 +21850,66 @@ func (ec *executionContext) fieldContext_ProviderRevision_unstructured(ctx conte
 	fc = &graphql.FieldContext{
 		Object:     "ProviderRevision",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProviderRevision_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ProviderRevision) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProviderRevision_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProviderRevision_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProviderRevision",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ProviderRevision_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -19414,6 +22014,8 @@ func (ec *executionContext) fieldContext_ProviderRevisionConnection_nodes(ctx co
 				return ec.fieldContext_ProviderRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ProviderRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ProviderRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ProviderRevision_events(ctx, field)
 			}
@@ -20609,6 +23211,8 @@ func (ec *executionContext) fieldContext_Query_secret(ctx context.Context, field
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -20677,6 +23281,8 @@ func (ec *executionContext) fieldContext_Query_configMap(ctx context.Context, fi
 				return ec.fieldContext_ConfigMap_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ConfigMap_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ConfigMap_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ConfigMap_events(ctx, field)
 			}
@@ -21601,7 +24207,7 @@ func (ec *executionContext) _Secret_unstructured(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -21622,11 +24228,66 @@ func (ec *executionContext) fieldContext_Secret_unstructured(ctx context.Context
 	fc = &graphql.FieldContext{
 		Object:     "Secret",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Secret_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Secret) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Secret_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Secret_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Secret",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Secret_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -24260,6 +26921,11 @@ func (ec *executionContext) _CompositeResource(ctx context.Context, sel ast.Sele
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._CompositeResource_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -24392,6 +27058,11 @@ func (ec *executionContext) _CompositeResourceClaim(ctx context.Context, sel ast
 			out.Values[i] = ec._CompositeResourceClaim_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._CompositeResourceClaim_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._CompositeResourceClaim_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -24953,6 +27624,11 @@ func (ec *executionContext) _CompositeResourceDefinition(ctx context.Context, se
 			out.Values[i] = ec._CompositeResourceDefinition_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._CompositeResourceDefinition_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._CompositeResourceDefinition_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -25876,6 +28552,11 @@ func (ec *executionContext) _Composition(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._Composition_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -26147,6 +28828,11 @@ func (ec *executionContext) _ConfigMap(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._ConfigMap_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -26246,6 +28932,11 @@ func (ec *executionContext) _Configuration(ctx context.Context, sel ast.Selectio
 			out.Values[i] = ec._Configuration_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._Configuration_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._Configuration_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -26458,6 +29149,11 @@ func (ec *executionContext) _ConfigurationRevision(ctx context.Context, sel ast.
 			out.Values[i] = ec._ConfigurationRevision_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ConfigurationRevision_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ConfigurationRevision_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -26946,6 +29642,11 @@ func (ec *executionContext) _CustomResourceDefinition(ctx context.Context, sel a
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._CustomResourceDefinition_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -27425,6 +30126,11 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._Event_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -27558,6 +30264,11 @@ func (ec *executionContext) _GenericResource(ctx context.Context, sel ast.Select
 			}
 		case "unstructured":
 			out.Values[i] = ec._GenericResource_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._GenericResource_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -27776,6 +30487,11 @@ func (ec *executionContext) _ManagedResource(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._ManagedResource_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ManagedResource_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ManagedResource_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -28391,6 +31107,11 @@ func (ec *executionContext) _Provider(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._Provider_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -28554,6 +31275,11 @@ func (ec *executionContext) _ProviderConfig(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._ProviderConfig_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ProviderConfig_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ProviderConfig_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -28807,6 +31533,11 @@ func (ec *executionContext) _ProviderRevision(ctx context.Context, sel ast.Selec
 			out.Values[i] = ec._ProviderRevision_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ProviderRevision_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ProviderRevision_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -29498,6 +32229,11 @@ func (ec *executionContext) _Secret(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec._Secret_data(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._Secret_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._Secret_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -155,8 +155,8 @@ func GetCompositionStatus(in extv1.CompositionStatus) *CompositionStatus {
 }
 
 // GetComposition from the supplied Crossplane Composition.
-func GetComposition(cmp *extv1.Composition) Composition {
-	return Composition{
+func GetComposition(cmp *extv1.Composition, s SelectedFields) Composition {
+	out := Composition{
 		ID: ReferenceID{
 			APIVersion: cmp.APIVersion,
 			Kind:       cmp.Kind,
@@ -172,9 +172,12 @@ func GetComposition(cmp *extv1.Composition) Composition {
 			},
 			WriteConnectionSecretsToNamespace: cmp.Spec.WriteConnectionSecretsToNamespace,
 		},
-		Status:       GetCompositionStatus(cmp.Status),
-		Unstructured: unstruct(cmp),
+		Status: GetCompositionStatus(cmp.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(cmp)
+	}
+	return out
 }
 
 /* Handle deprecated items preferring non-deprecated */

--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -140,8 +140,8 @@ func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition, s Se
 		},
 		Status: GetCompositeResourceDefinitionStatus(xrd.Status),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(xrd)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(xrd)
 	}
 	return out
 }
@@ -174,8 +174,8 @@ func GetComposition(cmp *extv1.Composition, s SelectedFields) Composition {
 		},
 		Status: GetCompositionStatus(cmp.Status),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(cmp)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(cmp)
 	}
 	return out
 }

--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -120,8 +120,8 @@ func GetCompositeResourceDefinitionStatus(in extv1.CompositeResourceDefinitionSt
 }
 
 // GetCompositeResourceDefinition from the supplied Crossplane XRD.
-func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition) CompositeResourceDefinition {
-	return CompositeResourceDefinition{
+func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition, s SelectedFields) CompositeResourceDefinition {
+	out := CompositeResourceDefinition{
 		ID: ReferenceID{
 			APIVersion: xrd.APIVersion,
 			Kind:       xrd.Kind,
@@ -138,9 +138,12 @@ func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition) Comp
 			DefaultCompositionReference:  xrd.Spec.DefaultCompositionRef,
 			EnforcedCompositionReference: xrd.Spec.EnforcedCompositionRef,
 		},
-		Status:       GetCompositeResourceDefinitionStatus(xrd.Status),
-		Unstructured: unstruct(xrd),
+		Status: GetCompositeResourceDefinitionStatus(xrd.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(xrd)
+	}
+	return out
 }
 
 // GetCompositionStatus from the supplied Crossplane status.

--- a/internal/graph/model/apiextensions_test.go
+++ b/internal/graph/model/apiextensions_test.go
@@ -162,8 +162,8 @@ func TestGetCompositeResourceDefinition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResourceDefinition(tc.xrd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CompositeResourceDefinition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetCompositeResourceDefinition(tc.xrd, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCompositeResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/apiextensions_test.go
+++ b/internal/graph/model/apiextensions_test.go
@@ -161,7 +161,7 @@ func TestGetCompositeResourceDefinition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResourceDefinition(tc.xrd, SkipFields(FieldUnstructured))
+			got := GetCompositeResourceDefinition(tc.xrd, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCompositeResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -240,7 +240,7 @@ func TestGetComposition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetComposition(tc.xrd, SkipFields(FieldUnstructured))
+			got := GetComposition(tc.xrd, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetComposition(...): -want, +got\n:%s", tc.reason, diff)
 			}

--- a/internal/graph/model/apiextensions_test.go
+++ b/internal/graph/model/apiextensions_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -241,8 +240,8 @@ func TestGetComposition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetComposition(tc.xrd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Composition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetComposition(tc.xrd, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetComposition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -334,7 +334,7 @@ func GetCustomResourceDefinitionFromCRD(crd *kextv1.CustomResourceDefinition) Cu
 // unstructured data contains (e.g. a managed resource, a provider, etc) and
 // return the appropriate model type. If no type can be detected it returns a
 // GenericResource.
-func GetKubernetesResource(u *kunstructured.Unstructured) (KubernetesResource, error) { //nolint:gocyclo
+func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (KubernetesResource, error) { //nolint:gocyclo
 	// This isn't _really_ that complex; it's a long but simple switch.
 
 	switch {
@@ -368,7 +368,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured) (KubernetesResource, e
 		if err := convert(u, pr); err != nil {
 			return nil, errors.Wrap(err, "cannot convert provider revision")
 		}
-		return GetProviderRevision(pr), nil
+		return GetProviderRevision(pr, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ConfigurationGroupVersionKind:
 		c := &pkgv1.Configuration{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -396,7 +396,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, cmp); err != nil {
 			return nil, errors.Wrap(err, "cannot convert composition")
 		}
-		return GetComposition(cmp), nil
+		return GetComposition(cmp, s), nil
 
 	case u.GroupVersionKind() == schema.GroupVersionKind{Group: kextv1.GroupName, Version: "v1", Kind: "CustomResourceDefinition"}:
 		crd := &unstructured.CustomResourceDefinition{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -109,19 +109,22 @@ func GetLabelSelector(s *metav1.LabelSelector) *LabelSelector {
 }
 
 // GetGenericResource from the suppled Kubernetes resource.
-func GetGenericResource(u *kunstructured.Unstructured) GenericResource {
-	return GenericResource{
+func GetGenericResource(u *kunstructured.Unstructured, s SelectedFields) GenericResource {
+	out := GenericResource{
 		ID: ReferenceID{
 			APIVersion: u.GetAPIVersion(),
 			Kind:       u.GetKind(),
 			Namespace:  u.GetNamespace(),
 			Name:       u.GetName(),
 		},
-		APIVersion:   u.GetAPIVersion(),
-		Kind:         u.GetKind(),
-		Metadata:     GetObjectMeta(u),
-		Unstructured: bytesForUnstructured(u),
+		APIVersion: u.GetAPIVersion(),
+		Kind:       u.GetKind(),
+		Metadata:   GetObjectMeta(u),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }
 
 // Data of this secret.
@@ -431,7 +434,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		return GetConfigMap(cm, s), nil
 
 	default:
-		return GetGenericResource(u), nil
+		return GetGenericResource(u, s), nil
 	}
 }
 

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -284,8 +284,8 @@ func GetCustomResourceDefinitionStatus(in kextv1.CustomResourceDefinitionStatus)
 }
 
 // GetCustomResourceDefinition from the suppled Kubernetes CRD.
-func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition) CustomResourceDefinition {
-	return CustomResourceDefinition{
+func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition, s SelectedFields) CustomResourceDefinition {
+	out := CustomResourceDefinition{
 		ID: ReferenceID{
 			APIVersion: crd.GetAPIVersion(),
 			Kind:       crd.GetKind(),
@@ -301,9 +301,12 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition) Cus
 			Scope:    GetResourceScope(crd.GetSpecScope()),
 			Versions: GetCustomResourceDefinitionVersions(crd.GetSpecVersions()),
 		},
-		Status:       GetCustomResourceDefinitionStatus(crd.GetStatus()),
-		Unstructured: bytesForUnstructured(&crd.Unstructured),
+		Status: GetCustomResourceDefinitionStatus(crd.GetStatus()),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(&crd.Unstructured)
+	}
+	return out
 }
 
 // GetCustomResourceDefinitionFromCRD from the suppled Kubernetes CRD.
@@ -405,7 +408,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, crd); err != nil {
 			return nil, errors.Wrap(err, "cannot convert custom resource definition")
 		}
-		return GetCustomResourceDefinition(crd), nil
+		return GetCustomResourceDefinition(crd, s), nil
 
 	case u.GroupVersionKind() == schema.GroupVersionKind{Group: corev1.GroupName, Version: "v1", Kind: "Secret"}:
 		sec := &corev1.Secret{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -375,7 +375,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, c); err != nil {
 			return nil, errors.Wrap(err, "cannot convert configuration")
 		}
-		return GetConfiguration(c), nil
+		return GetConfiguration(c, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ConfigurationRevisionGroupVersionKind:
 		cr := &pkgv1.ConfigurationRevision{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -361,7 +361,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, p); err != nil {
 			return nil, errors.Wrap(err, "cannot convert provider")
 		}
-		return GetProvider(p), nil
+		return GetProvider(p, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ProviderRevisionGroupVersionKind:
 		pr := &pkgv1.ProviderRevision{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -185,20 +185,23 @@ func GetSecret(s *corev1.Secret, sel SelectedFields) Secret {
 }
 
 // GetConfigMap from the supplied Kubernetes ConfigMap.
-func GetConfigMap(cm *corev1.ConfigMap) ConfigMap {
-	return ConfigMap{
+func GetConfigMap(cm *corev1.ConfigMap, s SelectedFields) ConfigMap {
+	out := ConfigMap{
 		ID: ReferenceID{
 			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "ConfigMap",
 			Namespace:  cm.GetNamespace(),
 			Name:       cm.GetName(),
 		},
-		APIVersion:   corev1.SchemeGroupVersion.String(),
-		Kind:         "ConfigMap",
-		Metadata:     GetObjectMeta(cm),
-		Unstructured: unstruct(cm),
-		data:         cm.Data,
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "ConfigMap",
+		Metadata:   GetObjectMeta(cm),
+		data:       cm.Data,
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(cm)
+	}
+	return out
 }
 
 // GetCustomResourceDefinitionNames from the supplied Kubernetes names.
@@ -425,7 +428,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, cm); err != nil {
 			return nil, errors.Wrap(err, "cannot convert config map")
 		}
-		return GetConfigMap(cm), nil
+		return GetConfigMap(cm, s), nil
 
 	default:
 		return GetGenericResource(u), nil

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -346,7 +346,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		return GetCompositeResource(u, s), nil
 
 	case unstructured.ProbablyClaim(u):
-		return GetCompositeResourceClaim(u), nil
+		return GetCompositeResourceClaim(u, s), nil
 
 	// Note that order is important here. We want to check whether the resource
 	// seems to be a managed resource _after_ checking whether it seems to be a

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -382,7 +382,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, cr); err != nil {
 			return nil, errors.Wrap(err, "cannot convert configuration revision")
 		}
-		return GetConfigurationRevision(cr), nil
+		return GetConfigurationRevision(cr, s), nil
 
 	case u.GroupVersionKind() == extv1.CompositeResourceDefinitionGroupVersionKind:
 		xrd := &extv1.CompositeResourceDefinition{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -354,7 +354,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 	// that would pass the ProbablyManaged check. Such a composite resource
 	// would very likely pass the ProbablyComposite check and never reach this.
 	case unstructured.ProbablyManaged(u):
-		return GetManagedResource(u), nil
+		return GetManagedResource(u, s), nil
 
 	case u.GroupVersionKind() == pkgv1.ProviderGroupVersionKind:
 		p := &pkgv1.Provider{}

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -318,29 +318,6 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition, s S
 	return out
 }
 
-// GetCustomResourceDefinitionFromCRD from the suppled Kubernetes CRD.
-func GetCustomResourceDefinitionFromCRD(crd *kextv1.CustomResourceDefinition) CustomResourceDefinition {
-	return CustomResourceDefinition{
-		ID: ReferenceID{
-			APIVersion: crd.APIVersion,
-			Kind:       crd.Kind,
-			Name:       crd.GetName(),
-		},
-
-		APIVersion: crd.APIVersion,
-		Kind:       crd.Kind,
-		Metadata:   GetObjectMeta(crd),
-		Spec: CustomResourceDefinitionSpec{
-			Group:    crd.Spec.Group,
-			Names:    *GetCustomResourceDefinitionNames(crd.Spec.Names),
-			Scope:    GetResourceScope(crd.Spec.Scope),
-			Versions: GetCustomResourceDefinitionVersions(crd.Spec.Versions),
-		},
-		Status:       GetCustomResourceDefinitionStatus(crd.Status),
-		Unstructured: unstruct(crd),
-	}
-}
-
 // GetKubernetesResource from the supplied unstructured Kubernetes resource.
 // GetKubernetesResource attempts to determine what type of resource the
 // unstructured data contains (e.g. a managed resource, a provider, etc) and

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -343,7 +343,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		return GetProviderConfig(u, s), nil
 
 	case unstructured.ProbablyComposite(u):
-		return GetCompositeResource(u), nil
+		return GetCompositeResource(u, s), nil
 
 	case unstructured.ProbablyClaim(u):
 		return GetCompositeResourceClaim(u), nil

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -340,7 +340,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 	switch {
 
 	case unstructured.ProbablyProviderConfig(u):
-		return GetProviderConfig(u), nil
+		return GetProviderConfig(u, s), nil
 
 	case unstructured.ProbablyComposite(u):
 		return GetCompositeResource(u), nil

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	extv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 
@@ -121,8 +122,8 @@ func GetGenericResource(u *kunstructured.Unstructured, s SelectedFields) Generic
 		Kind:       u.GetKind(),
 		Metadata:   GetObjectMeta(u),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = bytesForUnstructured(u)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = fieldpath.Pave(u.Object)
 	}
 	return out
 }
@@ -180,8 +181,8 @@ func GetSecret(s *corev1.Secret, sel SelectedFields) Secret {
 		out.Type = pointer.String(string(s.Type))
 	}
 
-	if sel.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(s)
+	if sel.Has(FieldUnstructured) || sel.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(s)
 	}
 
 	return out
@@ -201,8 +202,8 @@ func GetConfigMap(cm *corev1.ConfigMap, s SelectedFields) ConfigMap {
 		Metadata:   GetObjectMeta(cm),
 		data:       cm.Data,
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(cm)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(cm)
 	}
 	return out
 }
@@ -312,8 +313,8 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition, s S
 		},
 		Status: GetCustomResourceDefinitionStatus(crd.GetStatus()),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = bytesForUnstructured(&crd.Unstructured)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = fieldpath.Pave(crd.Unstructured.Object)
 	}
 	return out
 }

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -389,7 +389,7 @@ func GetKubernetesResource(u *kunstructured.Unstructured, s SelectedFields) (Kub
 		if err := convert(u, xrd); err != nil {
 			return nil, errors.Wrap(err, "cannot convert composite resource definition")
 		}
-		return GetCompositeResourceDefinition(xrd), nil
+		return GetCompositeResourceDefinition(xrd, s), nil
 
 	case u.GroupVersionKind() == extv1.CompositionGroupVersionKind:
 		cmp := &extv1.Composition{}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -735,7 +735,7 @@ func TestGetKubernetesResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			kr, err := GetKubernetesResource(tc.u)
+			kr, err := GetKubernetesResource(tc.u, SelectAll)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("GetKubernetesResource(...): -want error, +got error:\n%s", diff)
 			}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -110,8 +110,8 @@ func TestGetGenericResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetGenericResource(tc.u)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(GenericResource{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetGenericResource(tc.u, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetGenericResource(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -109,7 +109,7 @@ func TestGetGenericResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetGenericResource(tc.u, SkipFields(FieldUnstructured))
+			got := GetGenericResource(tc.u, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetGenericResource(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -210,7 +210,7 @@ func TestGetSecret(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetSecret(tc.s, SkipFields(FieldUnstructured))
+			got := GetSecret(tc.s, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(Secret{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -308,7 +308,7 @@ func TestGetConfigMap(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfigMap(tc.cm, SkipFields(FieldUnstructured))
+			got := GetConfigMap(tc.cm, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ConfigMap{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -419,7 +419,7 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCustomResourceDefinition(tc.crd, SkipFields(FieldUnstructured))
+			got := GetCustomResourceDefinition(tc.crd, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCustomResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -720,7 +720,7 @@ func TestGetKubernetesResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			kr, err := GetKubernetesResource(tc.u, SkipFields(FieldUnstructured))
+			kr, err := GetKubernetesResource(tc.u, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("GetKubernetesResource(...): -want error, +got error:\n%s", diff)
 			}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -309,8 +309,8 @@ func TestGetConfigMap(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfigMap(tc.cm)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigMap{}, "Unstructured"), cmp.AllowUnexported(ConfigMap{}, ObjectMeta{})); diff != "" {
+			got := GetConfigMap(tc.cm, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ConfigMap{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -431,20 +430,6 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 func TestGetKubernetesResource(t *testing.T) {
 	ignore := []cmp.Option{
 		cmp.AllowUnexported(Secret{}, ConfigMap{}, ObjectMeta{}),
-		cmpopts.IgnoreFields(ManagedResource{}, "Unstructured"),
-		cmpopts.IgnoreFields(ProviderConfig{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResource{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResourceClaim{}, "Unstructured"),
-		cmpopts.IgnoreFields(Provider{}, "Unstructured"),
-		cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"),
-		cmpopts.IgnoreFields(Configuration{}, "Unstructured"),
-		cmpopts.IgnoreFields(ConfigurationRevision{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResourceDefinition{}, "Unstructured"),
-		cmpopts.IgnoreFields(Composition{}, "Unstructured"),
-		cmpopts.IgnoreFields(CustomResourceDefinition{}, "Unstructured"),
-		cmpopts.IgnoreFields(Secret{}, "Unstructured"),
-		cmpopts.IgnoreFields(ConfigMap{}, "Unstructured"),
-		cmpopts.IgnoreFields(GenericResource{}, "Unstructured"),
 	}
 
 	dp := DeletionPolicyDelete
@@ -735,7 +720,7 @@ func TestGetKubernetesResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			kr, err := GetKubernetesResource(tc.u, SelectAll)
+			kr, err := GetKubernetesResource(tc.u, SkipFields(FieldUnstructured))
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("GetKubernetesResource(...): -want error, +got error:\n%s", diff)
 			}

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -211,8 +211,8 @@ func TestGetSecret(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetSecret(tc.s)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Secret{}, "Unstructured"), cmp.AllowUnexported(Secret{}, ObjectMeta{})); diff != "" {
+			got := GetSecret(tc.s, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(Secret{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -420,8 +420,8 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCustomResourceDefinition(tc.crd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CustomResourceDefinition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetCustomResourceDefinition(tc.crd, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCustomResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -20,6 +20,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 
 	"github.com/upbound/xgql/internal/unstructured"
 )
@@ -76,8 +77,8 @@ func GetCompositeResource(u *kunstructured.Unstructured, s SelectedFields) Compo
 		},
 		Status: GetCompositeResourceStatus(xr),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = bytesForUnstructured(u)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = fieldpath.Pave(u.Object)
 	}
 	return out
 }
@@ -145,8 +146,8 @@ func GetCompositeResourceClaim(u *kunstructured.Unstructured, s SelectedFields) 
 		},
 		Status: GetCompositeResourceClaimStatus(xrc),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = bytesForUnstructured(u)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = fieldpath.Pave(u.Object)
 	}
 	return out
 }

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -124,9 +124,9 @@ func GetCompositeResourceClaimStatus(xrc *unstructured.Claim) *CompositeResource
 }
 
 // GetCompositeResourceClaim from the supplied Crossplane claim.
-func GetCompositeResourceClaim(u *kunstructured.Unstructured) CompositeResourceClaim {
+func GetCompositeResourceClaim(u *kunstructured.Unstructured, s SelectedFields) CompositeResourceClaim {
 	xrc := &unstructured.Claim{Unstructured: *u}
-	return CompositeResourceClaim{
+	out := CompositeResourceClaim{
 		ID: ReferenceID{
 			APIVersion: xrc.GetAPIVersion(),
 			Kind:       xrc.GetKind(),
@@ -143,7 +143,10 @@ func GetCompositeResourceClaim(u *kunstructured.Unstructured) CompositeResourceC
 			ResourceReference:                xrc.GetResourceReference(),
 			WriteConnectionSecretToReference: delocalize(xrc.GetWriteConnectionSecretToReference(), xrc.GetNamespace()),
 		},
-		Status:       GetCompositeResourceClaimStatus(xrc),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetCompositeResourceClaimStatus(xrc),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -76,7 +76,7 @@ func GetCompositeResource(u *kunstructured.Unstructured, s SelectedFields) Compo
 		},
 		Status: GetCompositeResourceStatus(xr),
 	}
-	if s.Has("unstructured") {
+	if s.Has(FieldUnstructured) {
 		out.Unstructured = bytesForUnstructured(u)
 	}
 	return out

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -55,9 +55,9 @@ func GetCompositeResourceStatus(xr *unstructured.Composite) *CompositeResourceSt
 }
 
 // GetCompositeResource from the supplied Crossplane resource.
-func GetCompositeResource(u *kunstructured.Unstructured) CompositeResource {
+func GetCompositeResource(u *kunstructured.Unstructured, s SelectedFields) CompositeResource {
 	xr := &unstructured.Composite{Unstructured: *u}
-	return CompositeResource{
+	out := CompositeResource{
 		ID: ReferenceID{
 			APIVersion: xr.GetAPIVersion(),
 			Kind:       xr.GetKind(),
@@ -74,9 +74,12 @@ func GetCompositeResource(u *kunstructured.Unstructured) CompositeResource {
 			ResourceReferences:               xr.GetResourceReferences(),
 			WriteConnectionSecretToReference: xr.GetWriteConnectionSecretToReference(),
 		},
-		Status:       GetCompositeResourceStatus(xr),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetCompositeResourceStatus(xr),
 	}
+	if s.Has("unstructured") {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }
 
 func delocalize(ref *xpv1.LocalSecretReference, namespace string) *xpv1.SecretReference {

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -179,11 +179,10 @@ func TestGetCompositeResourceClaim(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResourceClaim(tc.u)
+			got := GetCompositeResourceClaim(tc.u, SkipFields(FieldUnstructured))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,
-				cmpopts.IgnoreFields(CompositeResourceClaim{}, "Unstructured"),
 				cmpopts.EquateApproxTime(1*time.Second),
 				cmp.AllowUnexported(ObjectMeta{}),
 			); diff != "" {

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -100,7 +100,7 @@ func TestGetCompositeResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResource(tc.u, SkipFields("unstructured"))
+			got := GetCompositeResource(tc.u, SkipFields(FieldUnstructured))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -100,7 +100,7 @@ func TestGetCompositeResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResource(tc.u, SkipFields(FieldUnstructured))
+			got := GetCompositeResource(tc.u, SkipFields(FieldUnstructured, FieldFieldPath))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,
@@ -179,7 +179,7 @@ func TestGetCompositeResourceClaim(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResourceClaim(tc.u, SkipFields(FieldUnstructured))
+			got := GetCompositeResourceClaim(tc.u, SkipFields(FieldUnstructured, FieldFieldPath))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -100,11 +100,10 @@ func TestGetCompositeResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetCompositeResource(tc.u)
+			got := GetCompositeResource(tc.u, SkipFields("unstructured"))
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,
-				cmpopts.IgnoreFields(CompositeResource{}, "Unstructured"),
 				cmpopts.EquateApproxTime(1*time.Second),
 				cmp.AllowUnexported(ObjectMeta{}),
 			); diff != "" {

--- a/internal/graph/model/event.go
+++ b/internal/graph/model/event.go
@@ -34,7 +34,7 @@ func GetEventType(in string) *EventType {
 }
 
 // GetEvent from the supplied Kubernetes event.
-func GetEvent(e *corev1.Event) Event {
+func GetEvent(e *corev1.Event, s SelectedFields) Event {
 	out := Event{
 		ID: ReferenceID{
 			APIVersion: e.APIVersion,
@@ -46,7 +46,6 @@ func GetEvent(e *corev1.Event) Event {
 		Kind:              e.Kind,
 		Metadata:          GetObjectMeta(e),
 		Type:              GetEventType(e.Type),
-		Unstructured:      unstruct(e),
 		InvolvedObjectRef: e.InvolvedObject,
 	}
 
@@ -67,6 +66,10 @@ func GetEvent(e *corev1.Event) Event {
 	out.FirstTime = &ft
 	lt := e.LastTimestamp.Time
 	out.LastTime = &lt
+
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(e)
+	}
 
 	return out
 }

--- a/internal/graph/model/event.go
+++ b/internal/graph/model/event.go
@@ -67,8 +67,8 @@ func GetEvent(e *corev1.Event, s SelectedFields) Event {
 	lt := e.LastTimestamp.Time
 	out.LastTime = &lt
 
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(e)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(e)
 	}
 
 	return out

--- a/internal/graph/model/event_test.go
+++ b/internal/graph/model/event_test.go
@@ -89,7 +89,7 @@ func TestGetEvent(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetEvent(tc.s, SkipFields(FieldUnstructured))
+			got := GetEvent(tc.s, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetEvent(...): -want, +got\n:%s", tc.reason, diff)
 			}

--- a/internal/graph/model/event_test.go
+++ b/internal/graph/model/event_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kschema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,8 +89,8 @@ func TestGetEvent(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetEvent(tc.s)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Event{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetEvent(tc.s, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetEvent(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/fieldpath.go
+++ b/internal/graph/model/fieldpath.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SkipUnstructured is a marker type. It is used in the schema via a `@goType` directive
+// to change all "unstructured" fields to this type and make them embedded. This prevents
+// gqlgen from generating resolver logic for these fields and instead makes it delegate
+// resolutions to PavedAccess, which is also embedded via the `@goType` directive.
+type SkipUnstructured interface{}
+
+// PavedAccess is an embedded resolver for "unstructured" and "fieldPath" fields.
+// It is embedded in generated types via a `@goType` directive.
+type PavedAccess struct {
+	*fieldpath.Paved
+}
+
+// Unstructured implements the "unstructured" field and returns the JSON representation
+// of the entire object.
+func (f PavedAccess) Unstructured() []byte {
+	return raw(f.Paved)
+}
+
+// FieldPath implements the "fieldPath" field and returns the JSON representation
+// of the value at the given path.
+func (f PavedAccess) FieldPath(path *string) ([]byte, error) {
+	if path == nil || len(*path) == 0 {
+		return f.Unstructured(), nil
+	}
+	return fieldPath(f.Paved, *path)
+}
+
+// raw returns the supplied object as unstructured JSON bytes. It panics if
+// the object cannot be marshalled as JSON, which _should_ only happen if this
+// program is fundamentally broken - e.g. trying to use a weird runtime.Object.
+func raw(paved *fieldpath.Paved) []byte {
+	out, err := json.Marshal(paved)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+// fieldPathWildcard expands the wildcard field path and returns the values at
+// the resulting field paths for the supplied object as JSON bytes. It panics if
+// the object cannot be marshalled as JSON, which _should_ only happen if this
+// program is fundamentally broken.
+func fieldPathWildcard(paved *fieldpath.Paved, path string) ([]byte, error) {
+	arrayFieldPaths, err := paved.ExpandWildcards(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(arrayFieldPaths) == 0 {
+		return nil, errors.Errorf("cannot expand path %q", path)
+	}
+
+	array := make([]interface{}, 0, len(arrayFieldPaths))
+	for _, arrayFieldPath := range arrayFieldPaths {
+		v, err := paved.GetValue(arrayFieldPath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot get value at path %q", arrayFieldPath)
+		}
+		array = append(array, v)
+	}
+	out, err := json.Marshal(array)
+	if err != nil {
+		panic(err)
+	}
+	return out, nil
+}
+
+// fieldPath returns the value at the supplied field path for the supplied
+// object as JSON bytes. It panics if the object cannot be marshalled as JSON,
+// which _should_ only happen if this program is fundamentally broken.
+func fieldPath(paved *fieldpath.Paved, path string) ([]byte, error) {
+	if strings.Contains(path, "[*]") {
+		return fieldPathWildcard(paved, path)
+	}
+	v, err := paved.GetValue(path)
+	if err != nil {
+		return nil, err
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return out, nil
+}
+
+func paveObject(o runtime.Object) *fieldpath.Paved {
+	p, err := fieldpath.PaveObject(o)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}

--- a/internal/graph/model/generated.go
+++ b/internal/graph/model/generated.go
@@ -63,7 +63,77 @@ type CompositeResource struct {
 	// The observed state of this resource.
 	Status *CompositeResourceStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -89,7 +159,77 @@ type CompositeResourceClaim struct {
 	// The observed state of this resource.
 	Status *CompositeResourceClaimStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -160,7 +300,77 @@ type CompositeResourceDefinition struct {
 	// The observed state of this resource.
 	Status *CompositeResourceDefinitionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The generated `CustomResourceDefinition` for this XRD
@@ -291,7 +501,77 @@ type Composition struct {
 	// The observed state of this resource.
 	Status *CompositionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -360,7 +640,77 @@ type ConfigMap struct {
 	// The data stored in this config map.
 	data map[string]string `json:"data,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -384,7 +734,77 @@ type Configuration struct {
 	// The observed state of this resource.
 	Status *ConfigurationStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// Revisions of this configuration.
@@ -420,7 +840,77 @@ type ConfigurationRevision struct {
 	// The observed state of this resource.
 	Status *ConfigurationRevisionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -573,7 +1063,77 @@ type CustomResourceDefinition struct {
 	// The observed state of this resource.
 	Status *CustomResourceDefinitionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// Custom resources defined by this CRD
@@ -725,7 +1285,77 @@ type Event struct {
 	// The time at which this event was most recently recorded.
 	LastTime *time.Time `json:"lastTime,omitempty"`
 	// An unstructured JSON representation of the event.
-	Unstructured      []byte              `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess       `json:"fieldPath"`
 	InvolvedObjectRef v11.ObjectReference `json:"-"`
 }
 
@@ -760,7 +1390,77 @@ type GenericResource struct {
 	// Metadata that is common to all Kubernetes API resources.
 	Metadata ObjectMeta `json:"metadata"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -807,7 +1507,77 @@ type ManagedResource struct {
 	// The observed state of this resource.
 	Status *ManagedResourceStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -921,7 +1691,77 @@ type Provider struct {
 	// The observed state of this resource.
 	Status *ProviderStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// Revisions of this provider.
@@ -948,7 +1788,77 @@ type ProviderConfig struct {
 	// The observed state of this resource.
 	Status *ProviderConfigStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -998,7 +1908,77 @@ type ProviderRevision struct {
 	// The observed state of this resource.
 	Status *ProviderRevisionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -1114,7 +2094,77 @@ type Secret struct {
 	// The data stored in this secret. Values are not base64 encoded.
 	data map[string]string `json:"data,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }

--- a/internal/graph/model/managed.go
+++ b/internal/graph/model/managed.go
@@ -18,6 +18,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 
 	"github.com/upbound/xgql/internal/unstructured"
 )
@@ -81,8 +82,8 @@ func GetManagedResource(u *kunstructured.Unstructured, s SelectedFields) Managed
 		},
 		Status: GetManagedResourceStatus(mg),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = bytesForUnstructured(u)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = fieldpath.Pave(u.Object)
 	}
 	return out
 }

--- a/internal/graph/model/managed.go
+++ b/internal/graph/model/managed.go
@@ -62,9 +62,9 @@ func GetManagedResourceStatus(in *unstructured.Managed) *ManagedResourceStatus {
 }
 
 // GetManagedResource from the supplied Crossplane resource.
-func GetManagedResource(u *kunstructured.Unstructured) ManagedResource {
+func GetManagedResource(u *kunstructured.Unstructured, s SelectedFields) ManagedResource {
 	mg := &unstructured.Managed{Unstructured: *u}
-	return ManagedResource{
+	out := ManagedResource{
 		ID: ReferenceID{
 			APIVersion: mg.GetAPIVersion(),
 			Kind:       mg.GetKind(),
@@ -79,7 +79,10 @@ func GetManagedResource(u *kunstructured.Unstructured) ManagedResource {
 			ProviderConfigRef:                GetProviderConfigReference(mg.GetProviderConfigReference()),
 			DeletionPolicy:                   GetDeletionPolicy(mg.GetDeletionPolicy()),
 		},
-		Status:       GetManagedResourceStatus(mg),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetManagedResourceStatus(mg),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }

--- a/internal/graph/model/managed_test.go
+++ b/internal/graph/model/managed_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -88,9 +87,9 @@ func TestGetManagedResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetManagedResource(tc.u)
+			got := GetManagedResource(tc.u, SkipFields(FieldUnstructured))
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ManagedResource{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetManagedResource(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/managed_test.go
+++ b/internal/graph/model/managed_test.go
@@ -87,7 +87,7 @@ func TestGetManagedResource(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetManagedResource(tc.u, SkipFields(FieldUnstructured))
+			got := GetManagedResource(tc.u, SkipFields(FieldUnstructured, FieldFieldPath))
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetManagedResource(...): -want, +got\n:%s", tc.reason, diff)

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -93,8 +93,8 @@ func GetProviderStatus(in pkgv1.ProviderStatus) *ProviderStatus {
 }
 
 // GetProvider from the supplied Kubernetes provider.
-func GetProvider(p *pkgv1.Provider) Provider {
-	return Provider{
+func GetProvider(p *pkgv1.Provider, s SelectedFields) Provider {
+	out := Provider{
 		ID: ReferenceID{
 			APIVersion: p.APIVersion,
 			Kind:       p.Kind,
@@ -112,9 +112,12 @@ func GetProvider(p *pkgv1.Provider) Provider {
 			IgnoreCrossplaneConstraints: p.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    p.Spec.SkipDependencyResolution,
 		},
-		Status:       GetProviderStatus(p.Status),
-		Unstructured: unstruct(p),
+		Status: GetProviderStatus(p.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(p)
+	}
+	return out
 }
 
 // GetPackageRevisionDesiredState from the supplies Crossplane state.

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -114,8 +114,8 @@ func GetProvider(p *pkgv1.Provider, s SelectedFields) Provider {
 		},
 		Status: GetProviderStatus(p.Status),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(p)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(p)
 	}
 	return out
 }
@@ -169,8 +169,8 @@ func GetProviderRevision(pr *pkgv1.ProviderRevision, s SelectedFields) ProviderR
 		},
 		Status: GetProviderRevisionStatus(pr.Status),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(pr)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(pr)
 	}
 	return out
 }
@@ -212,8 +212,8 @@ func GetConfiguration(c *pkgv1.Configuration, s SelectedFields) Configuration {
 		},
 		Status: GetConfigurationStatus(c.Status),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(c)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(c)
 	}
 	return out
 }
@@ -256,8 +256,8 @@ func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision, s SelectedFields)
 		},
 		Status: GetConfigurationRevisionStatus(cr.Status),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = unstruct(cr)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = paveObject(cr)
 	}
 	return out
 }

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -145,8 +145,8 @@ func GetProviderRevisionStatus(in pkgv1.PackageRevisionStatus) *ProviderRevision
 }
 
 // GetProviderRevision from the supplied Crossplane provider revision.
-func GetProviderRevision(pr *pkgv1.ProviderRevision) ProviderRevision {
-	return ProviderRevision{
+func GetProviderRevision(pr *pkgv1.ProviderRevision, s SelectedFields) ProviderRevision {
+	out := ProviderRevision{
 		ID: ReferenceID{
 			APIVersion: pr.APIVersion,
 			Kind:       pr.Kind,
@@ -164,9 +164,12 @@ func GetProviderRevision(pr *pkgv1.ProviderRevision) ProviderRevision {
 			IgnoreCrossplaneConstraints: pr.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    pr.Spec.SkipDependencyResolution,
 		},
-		Status:       GetProviderRevisionStatus(pr.Status),
-		Unstructured: unstruct(pr),
+		Status: GetProviderRevisionStatus(pr.Status),
 	}
+	if s.Has("unstructured") {
+		out.Unstructured = unstruct(pr)
+	}
+	return out
 }
 
 // GetConfigurationStatus from the supplied Kubernetes status.

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -191,8 +191,8 @@ func GetConfigurationStatus(in pkgv1.ConfigurationStatus) *ConfigurationStatus {
 }
 
 // GetConfiguration from the supplied Kubernetes configuration.
-func GetConfiguration(c *pkgv1.Configuration) Configuration {
-	return Configuration{
+func GetConfiguration(c *pkgv1.Configuration, s SelectedFields) Configuration {
+	out := Configuration{
 		ID: ReferenceID{
 			APIVersion: c.APIVersion,
 			Kind:       c.Kind,
@@ -210,9 +210,12 @@ func GetConfiguration(c *pkgv1.Configuration) Configuration {
 			IgnoreCrossplaneConstraints: c.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    c.Spec.SkipDependencyResolution,
 		},
-		Status:       GetConfigurationStatus(c.Status),
-		Unstructured: unstruct(c),
+		Status: GetConfigurationStatus(c.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(c)
+	}
+	return out
 }
 
 // GetConfigurationRevisionStatus from the supplied Crossplane provider revision.

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -166,7 +166,7 @@ func GetProviderRevision(pr *pkgv1.ProviderRevision, s SelectedFields) ProviderR
 		},
 		Status: GetProviderRevisionStatus(pr.Status),
 	}
-	if s.Has("unstructured") {
+	if s.Has(FieldUnstructured) {
 		out.Unstructured = unstruct(pr)
 	}
 	return out

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -235,8 +235,8 @@ func GetConfigurationRevisionStatus(in pkgv1.PackageRevisionStatus) *Configurati
 }
 
 // GetConfigurationRevision from the supplied Kubernetes provider revision.
-func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision) ConfigurationRevision {
-	return ConfigurationRevision{
+func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision, s SelectedFields) ConfigurationRevision {
+	out := ConfigurationRevision{
 		ID: ReferenceID{
 			APIVersion: cr.APIVersion,
 			Kind:       cr.Kind,
@@ -254,7 +254,10 @@ func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision) ConfigurationRevi
 			IgnoreCrossplaneConstraints: cr.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    cr.Spec.SkipDependencyResolution,
 		},
-		Status:       GetConfigurationRevisionStatus(cr.Status),
-		Unstructured: unstruct(cr),
+		Status: GetConfigurationRevisionStatus(cr.Status),
 	}
+	if s.Has(FieldUnstructured) {
+		out.Unstructured = unstruct(cr)
+	}
+	return out
 }

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -110,8 +110,8 @@ func TestGetProvider(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProvider(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Provider{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetProvider(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProvider(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -212,7 +212,7 @@ func TestGetProviderRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderRevision(tc.cfg)
+			got := GetProviderRevision(tc.cfg, SelectAll)
 			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -109,7 +109,7 @@ func TestGetProvider(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProvider(tc.cfg, SkipFields(FieldUnstructured))
+			got := GetProvider(tc.cfg, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProvider(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -211,7 +211,7 @@ func TestGetProviderRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderRevision(tc.cfg, SkipFields(FieldUnstructured))
+			got := GetProviderRevision(tc.cfg, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -301,7 +301,7 @@ func TestGetConfiguration(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfiguration(tc.cfg, SkipFields(FieldUnstructured))
+			got := GetConfiguration(tc.cfg, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfiguration(...): -want, +got\n:%s", tc.reason, diff)
 			}
@@ -403,7 +403,7 @@ func TestGetConfigurationRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfigurationRevision(tc.cfg, SkipFields(FieldUnstructured))
+			got := GetConfigurationRevision(tc.cfg, SkipFields(FieldUnstructured, FieldFieldPath))
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfigurationRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -302,8 +302,8 @@ func TestGetConfiguration(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfiguration(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Configuration{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetConfiguration(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfiguration(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,8 +211,8 @@ func TestGetProviderRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderRevision(tc.cfg, SelectAll)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetProviderRevision(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -404,8 +404,8 @@ func TestGetConfigurationRevision(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetConfigurationRevision(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigurationRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			got := GetConfigurationRevision(tc.cfg, SkipFields(FieldUnstructured))
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfigurationRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -38,19 +38,22 @@ func GetProviderConfigStatus(pc *unstructured.ProviderConfig) *ProviderConfigSta
 }
 
 // GetProviderConfig from the suppled Crossplane ProviderConfig.
-func GetProviderConfig(u *kunstructured.Unstructured) ProviderConfig {
+func GetProviderConfig(u *kunstructured.Unstructured, s SelectedFields) ProviderConfig {
 	pc := &unstructured.ProviderConfig{Unstructured: *u}
-	return ProviderConfig{
+	out := ProviderConfig{
 		ID: ReferenceID{
 			APIVersion: pc.GetAPIVersion(),
 			Kind:       pc.GetKind(),
 			Name:       pc.GetName(),
 		},
 
-		APIVersion:   pc.GetAPIVersion(),
-		Kind:         pc.GetKind(),
-		Metadata:     GetObjectMeta(pc),
-		Status:       GetProviderConfigStatus(pc),
-		Unstructured: bytesForUnstructured(u),
+		APIVersion: pc.GetAPIVersion(),
+		Kind:       pc.GetKind(),
+		Metadata:   GetObjectMeta(pc),
+		Status:     GetProviderConfigStatus(pc),
 	}
+	if s.Has("unstructured") {
+		out.Unstructured = bytesForUnstructured(u)
+	}
+	return out
 }

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -52,7 +52,7 @@ func GetProviderConfig(u *kunstructured.Unstructured, s SelectedFields) Provider
 		Metadata:   GetObjectMeta(pc),
 		Status:     GetProviderConfigStatus(pc),
 	}
-	if s.Has("unstructured") {
+	if s.Has(FieldUnstructured) {
 		out.Unstructured = bytesForUnstructured(u)
 	}
 	return out

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -17,6 +17,7 @@ package model
 import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/upbound/xgql/internal/unstructured"
@@ -52,8 +53,8 @@ func GetProviderConfig(u *kunstructured.Unstructured, s SelectedFields) Provider
 		Metadata:   GetObjectMeta(pc),
 		Status:     GetProviderConfigStatus(pc),
 	}
-	if s.Has(FieldUnstructured) {
-		out.Unstructured = bytesForUnstructured(u)
+	if s.Has(FieldUnstructured) || s.Has(FieldFieldPath) {
+		out.PavedAccess.Paved = fieldpath.Pave(u.Object)
 	}
 	return out
 }

--- a/internal/graph/model/providerconfig_test.go
+++ b/internal/graph/model/providerconfig_test.go
@@ -72,7 +72,7 @@ func TestGetProviderConfig(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderConfig(tc.u, SkipFields(FieldUnstructured))
+			got := GetProviderConfig(tc.u, SkipFields(FieldUnstructured, FieldFieldPath))
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderConfig(...): -want, +got\n:%s", tc.reason, diff)

--- a/internal/graph/model/providerconfig_test.go
+++ b/internal/graph/model/providerconfig_test.go
@@ -72,7 +72,7 @@ func TestGetProviderConfig(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderConfig(tc.u, SkipFields("unstructured"))
+			got := GetProviderConfig(tc.u, SkipFields(FieldUnstructured))
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderConfig(...): -want, +got\n:%s", tc.reason, diff)

--- a/internal/graph/model/providerconfig_test.go
+++ b/internal/graph/model/providerconfig_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -73,9 +72,9 @@ func TestGetProviderConfig(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := GetProviderConfig(tc.u)
+			got := GetProviderConfig(tc.u, SkipFields("unstructured"))
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderConfig{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderConfig(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/selection.go
+++ b/internal/graph/model/selection.go
@@ -14,6 +14,11 @@
 
 package model
 
+const (
+	FieldUnstructured = "unstructured"
+	FieldNodes        = "nodes"
+)
+
 // SelectedFields allows checking if a field was selected in a GraphQL query.
 // It uses "." as a separator for nested fields.
 // Example:

--- a/internal/graph/model/selection.go
+++ b/internal/graph/model/selection.go
@@ -16,6 +16,7 @@ package model
 
 const (
 	FieldUnstructured = "unstructured"
+	FieldFieldPath    = "fieldPath"
 	FieldNodes        = "nodes"
 )
 

--- a/internal/graph/model/selection.go
+++ b/internal/graph/model/selection.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// SelectedFields allows checking if a field was selected in a GraphQL query.
+// It uses "." as a separator for nested fields.
+// Example:
+//
+//	fields := GetSelectedFields(ctx)
+//	if fields.Has("user") {
+//	  // get base fields
+//	}
+//	if fields.Has("user.friends") {
+//	  // do some expensive operation
+//	}
+type SelectedFields interface {
+	Has(path string) bool
+}
+
+type selectFields bool
+
+func (s selectFields) Has(string) bool {
+	return bool(s)
+}
+
+var (
+	SelectAll  selectFields = true
+	SelectNone selectFields = false
+)
+
+type skipFields []string
+
+func (s skipFields) Has(path string) bool {
+	for _, f := range s {
+		if f == path {
+			return false
+		}
+		if len(f) > len(path) && f[:len(path)] == path && f[len(path)] == '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func SkipFields(paths ...string) SelectedFields {
+	return skipFields(paths)
+}

--- a/internal/graph/model/util.go
+++ b/internal/graph/model/util.go
@@ -15,35 +15,11 @@
 package model
 
 import (
-	"github.com/go-json-experiment/json"
-
 	"github.com/pkg/errors"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-// unstruct returns the supplied object as unstructured JSON bytes. It panics if
-// the object cannot be marshalled as JSON, which _should_ only happen if this
-// program is fundamentally broken - e.g. trying to use a weird runtime.Object.
-func unstruct(obj runtime.Object) []byte {
-	out, err := json.Marshal(obj)
-	if err != nil {
-		panic(err)
-	}
-	return out
-}
-
-// bytesForUnstructured returns the supplied unstructured.Unstructured as JSON
-// bytes. It panics if the object cannot be marshalled as JSON, which _should_
-// only happen if this program is fundamentally broken.
-func bytesForUnstructured(u *kunstructured.Unstructured) []byte {
-	out, err := json.Marshal(u.Object)
-	if err != nil {
-		panic(err)
-	}
-	return out
-}
 
 func convert(from *kunstructured.Unstructured, to runtime.Object) error {
 	c := runtime.DefaultUnstructuredConverter

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -75,7 +75,7 @@ func (r *xrd) getCrd(ctx context.Context, group string, names *model.CompositeRe
 		return nil, nil
 	}
 
-	out := model.GetCustomResourceDefinition(in)
+	out := model.GetCustomResourceDefinition(in, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -133,7 +133,7 @@ that is filtered and sorted
 */
 func getCompositeResourceConnection(ctx context.Context, in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceOptionsInput) model.CompositeResourceConnection {
 	xrs := []model.CompositeResource{}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		xr := model.GetCompositeResource(&in.Items[i], selectedFields)

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -124,18 +124,19 @@ func (r *xrd) DefinedCompositeResources(ctx context.Context, obj *model.Composit
 		return model.CompositeResourceConnection{}, nil
 	}
 
-	return getCompositeResourceConnection(in, options), nil
+	return getCompositeResourceConnection(ctx, in, options), nil
 }
 
 /*
 Produce a CompositeResourceClaimConnection from the raw k8s UnstructuredList
 that is filtered and sorted
 */
-func getCompositeResourceConnection(in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceOptionsInput) model.CompositeResourceConnection {
+func getCompositeResourceConnection(ctx context.Context, in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceOptionsInput) model.CompositeResourceConnection {
 	xrs := []model.CompositeResource{}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
-		xr := model.GetCompositeResource(&in.Items[i])
+		xr := model.GetCompositeResource(&in.Items[i], selectedFields)
 		if readyMatches(options.Ready, &xr) {
 			xrs = append(xrs, xr)
 		}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -199,18 +199,19 @@ func (r *xrd) DefinedCompositeResourceClaims(ctx context.Context, obj *model.Com
 		return model.CompositeResourceClaimConnection{}, nil
 	}
 
-	return getCompositeResourceClaimConnection(in, options), nil
+	return getCompositeResourceClaimConnection(ctx, in, options), nil
 }
 
 /*
 Produce a CompositeResourceClaimConnection from the raw k8s UnstructuredList
 that is filtered and sorted
 */
-func getCompositeResourceClaimConnection(in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceClaimOptionsInput) model.CompositeResourceClaimConnection {
+func getCompositeResourceClaimConnection(ctx context.Context, in *kunstructured.UnstructuredList, options *model.DefinedCompositeResourceClaimOptionsInput) model.CompositeResourceClaimConnection {
 	claims := []model.CompositeResourceClaim{}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
-		claim := model.GetCompositeResourceClaim(&in.Items[i])
+		claim := model.GetCompositeResourceClaim(&in.Items[i], selectedFields)
 		if readyMatches(options.Ready, &claim) {
 			claims = append(claims, claim)
 		}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -293,7 +293,7 @@ func (r *xrdSpec) DefaultComposition(ctx context.Context, obj *model.CompositeRe
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 
@@ -318,7 +318,7 @@ func (r *xrdSpec) EnforcedComposition(ctx context.Context, obj *model.CompositeR
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -269,16 +269,16 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xr := unstructured.Unstructured{}
-	gxr := model.GetCompositeResource(&xr)
+	gxr := model.GetCompositeResource(&xr, model.SelectAll)
 	xrReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrReady := model.GetCompositeResource(&xrReady)
+	gxrReady := model.GetCompositeResource(&xrReady, model.SelectAll)
 	xrNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrNotReady := model.GetCompositeResource(&xrNotReady)
+	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SelectAll)
 	xrReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown)
+	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SelectAll)
 
 	group := "example.org"
 	version := "v1"

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -1438,7 +1438,7 @@ func TestCompositeResourceDefinitionSpecDefaultComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -1569,7 +1569,7 @@ func TestCompositeResourceDefinitionSpecEnforcedComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -758,16 +758,16 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xrc := unstructured.Unstructured{}
-	gxrc := model.GetCompositeResourceClaim(&xrc)
+	gxrc := model.GetCompositeResourceClaim(&xrc, model.SelectAll)
 	xrcReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrcReady := model.GetCompositeResourceClaim(&xrcReady)
+	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SelectAll)
 	xrcNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady)
+	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SelectAll)
 	xrcReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown)
+	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SelectAll)
 
 	group := "example.org"
 	version := "v1"

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -144,7 +144,7 @@ func TestCompositeResourceCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -259,7 +259,7 @@ func TestCompositeResourceClaimCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -270,16 +270,16 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xr := unstructured.Unstructured{}
-	gxr := model.GetCompositeResource(&xr, model.SelectAll)
+	gxr := model.GetCompositeResource(&xr, model.SkipFields(model.FieldUnstructured))
 	xrReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrReady := model.GetCompositeResource(&xrReady, model.SelectAll)
+	gxrReady := model.GetCompositeResource(&xrReady, model.SkipFields(model.FieldUnstructured))
 	xrNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SelectAll)
+	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SkipFields(model.FieldUnstructured))
 	xrReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SelectAll)
+	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SkipFields(model.FieldUnstructured))
 
 	group := "example.org"
 	version := "v1"
@@ -747,7 +747,6 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.crc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResources(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -759,16 +758,16 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xrc := unstructured.Unstructured{}
-	gxrc := model.GetCompositeResourceClaim(&xrc, model.SelectAll)
+	gxrc := model.GetCompositeResourceClaim(&xrc, model.SkipFields(model.FieldUnstructured))
 	xrcReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SelectAll)
+	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SkipFields(model.FieldUnstructured))
 	xrcNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SelectAll)
+	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SkipFields(model.FieldUnstructured))
 	xrcReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SelectAll)
+	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SkipFields(model.FieldUnstructured))
 
 	group := "example.org"
 	version := "v1"
@@ -1424,7 +1423,6 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.crcc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -144,7 +144,7 @@ func TestCompositeResourceCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -259,7 +259,7 @@ func TestCompositeResourceClaimCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -270,16 +270,16 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xr := unstructured.Unstructured{}
-	gxr := model.GetCompositeResource(&xr, model.SkipFields(model.FieldUnstructured))
+	gxr := model.GetCompositeResource(&xr, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	xrReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrReady := model.GetCompositeResource(&xrReady, model.SkipFields(model.FieldUnstructured))
+	gxrReady := model.GetCompositeResource(&xrReady, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	xrNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SkipFields(model.FieldUnstructured))
+	gxrNotReady := model.GetCompositeResource(&xrNotReady, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	xrReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SkipFields(model.FieldUnstructured))
+	gxrReadyUnknown := model.GetCompositeResource(&xrReadyUnknown, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	group := "example.org"
 	version := "v1"
@@ -746,7 +746,7 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 				t.Errorf("\n%s\nq.DefinedCompositeResources(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.crc, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResources(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -758,16 +758,16 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	xrc := unstructured.Unstructured{}
-	gxrc := model.GetCompositeResourceClaim(&xrc, model.SkipFields(model.FieldUnstructured))
+	gxrc := model.GetCompositeResourceClaim(&xrc, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	xrcReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionTrue}})
-	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SkipFields(model.FieldUnstructured))
+	gxrcReady := model.GetCompositeResourceClaim(&xrcReady, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	xrcNotReady := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcNotReady.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionFalse}})
-	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SkipFields(model.FieldUnstructured))
+	gxrcNotReady := model.GetCompositeResourceClaim(&xrcNotReady, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	xrcReadyUnknown := unstructured.Unstructured{Object: map[string]interface{}{}}
 	fieldpath.Pave(xrcReadyUnknown.Object).SetValue("status.conditions", []xpv1.Condition{{Type: xpv1.TypeReady, Status: corev1.ConditionUnknown}})
-	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SkipFields(model.FieldUnstructured))
+	gxrcReadyUnknown := model.GetCompositeResourceClaim(&xrcReadyUnknown, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	group := "example.org"
 	version := "v1"
@@ -1422,7 +1422,7 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.crcc, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -1434,7 +1434,7 @@ func TestCompositeResourceDefinitionSpecDefaultComposition(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
-	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -1554,7 +1554,7 @@ func TestCompositeResourceDefinitionSpecDefaultComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.DefaultComposition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.DefaultComposition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1565,7 +1565,7 @@ func TestCompositeResourceDefinitionSpecEnforcedComposition(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
-	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -1685,7 +1685,7 @@ func TestCompositeResourceDefinitionSpecEnforcedComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.EnforcedComposition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.EnforcedComposition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/common.go
+++ b/internal/graph/resolvers/common.go
@@ -136,11 +136,12 @@ func (r *crd) DefinedResources(ctx context.Context, obj *model.CustomResourceDef
 		Nodes:      make([]model.KubernetesResource, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
 		u := in.Items[i]
 
-		kr, err := model.GetKubernetesResource(&u)
+		kr, err := model.GetKubernetesResource(&u, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelDefined))
 		}

--- a/internal/graph/resolvers/common.go
+++ b/internal/graph/resolvers/common.go
@@ -136,7 +136,7 @@ func (r *crd) DefinedResources(ctx context.Context, obj *model.CustomResourceDef
 		Nodes:      make([]model.KubernetesResource, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		u := in.Items[i]

--- a/internal/graph/resolvers/common_test.go
+++ b/internal/graph/resolvers/common_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -52,7 +53,7 @@ func TestCRDDefinedResources(t *testing.T) {
 
 	gr := unstructured.Unstructured{}
 	ggr := model.GetGenericResource(&gr, model.SelectAll)
-	ggrSkipUnstructured := model.GetGenericResource(&gr, model.SkipFields(model.FieldUnstructured))
+	ggrSkipUnstructured := model.GetGenericResource(&gr, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -346,7 +347,7 @@ func TestCRDDefinedResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.DefinedResources(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.DefinedResources(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -193,6 +193,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ResourceReferences)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for _, ref := range obj.ResourceReferences {
 		// Ignore nameless resource references
@@ -209,7 +210,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 			continue
 		}
 
-		kr, err := model.GetKubernetesResource(xrc)
+		kr, err := model.GetKubernetesResource(xrc, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelComposed))
 			continue

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -252,7 +252,7 @@ func (r *compositeResourceSpec) ConnectionSecret(ctx context.Context, obj *model
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }
 
@@ -426,7 +426,7 @@ func (r *compositeResourceClaimSpec) ConnectionSecret(ctx context.Context, obj *
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -193,7 +193,7 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ResourceReferences)),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for _, ref := range obj.ResourceReferences {
 		// Ignore nameless resource references

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -390,7 +390,7 @@ func (r *compositeResourceClaimSpec) Resource(ctx context.Context, obj *model.Co
 		return nil, nil
 	}
 
-	out := model.GetCompositeResource(xr)
+	out := model.GetCompositeResource(xr, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -130,7 +130,7 @@ func (r *compositeResourceSpec) Composition(ctx context.Context, obj *model.Comp
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 
@@ -360,7 +360,7 @@ func (r *compositeResourceClaimSpec) Composition(ctx context.Context, obj *model
 		return nil, nil
 	}
 
-	out := model.GetComposition(cmp)
+	out := model.GetComposition(cmp, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -171,7 +171,7 @@ func (r *compositeResourceSpec) Claim(ctx context.Context, obj *model.CompositeR
 		return nil, nil
 	}
 
-	out := model.GetCompositeResourceClaim(xrc)
+	out := model.GetCompositeResourceClaim(xrc, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -92,7 +92,7 @@ func (r *compositeResource) Definition(ctx context.Context, obj *model.Composite
 			continue
 		}
 
-		out := model.GetCompositeResourceDefinition(&xrd)
+		out := model.GetCompositeResourceDefinition(&xrd, GetSelectedFields(ctx))
 		return &out, nil
 	}
 
@@ -314,7 +314,7 @@ func (r *compositeResourceClaim) Definition(ctx context.Context, obj *model.Comp
 			continue
 		}
 
-		out := model.GetCompositeResourceDefinition(&xrd)
+		out := model.GetCompositeResourceDefinition(&xrd, GetSelectedFields(ctx))
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/composite.go
+++ b/internal/graph/resolvers/composite.go
@@ -17,6 +17,7 @@ package resolvers
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -195,30 +196,43 @@ func (r *compositeResourceSpec) Resources(ctx context.Context, obj *model.Compos
 	}
 	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
+	// Collect all concurrently.
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
 	for _, ref := range obj.ResourceReferences {
 		// Ignore nameless resource references
 		if ref.Name == "" {
 			continue
 		}
 
-		xrc := &unstructured.Unstructured{}
-		xrc.SetAPIVersion(ref.APIVersion)
-		xrc.SetKind(ref.Kind)
-		nn := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
-		if err := c.Get(ctx, nn, xrc); err != nil {
-			graphql.AddError(ctx, errors.Wrap(err, errGetComposed))
-			continue
-		}
+		ref := ref // So we don't take the address of a range variable.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			xrc := &unstructured.Unstructured{}
+			xrc.SetAPIVersion(ref.APIVersion)
+			xrc.SetKind(ref.Kind)
+			nn := types.NamespacedName{Namespace: ref.Namespace, Name: ref.Name}
+			if err := c.Get(ctx, nn, xrc); err != nil {
+				graphql.AddError(ctx, errors.Wrap(err, errGetComposed))
+				return
+			}
 
-		kr, err := model.GetKubernetesResource(xrc, selectedFields)
-		if err != nil {
-			graphql.AddError(ctx, errors.Wrap(err, errModelComposed))
-			continue
-		}
+			kr, err := model.GetKubernetesResource(xrc, selectedFields)
+			if err != nil {
+				graphql.AddError(ctx, errors.Wrap(err, errModelComposed))
+				return
+			}
 
-		out.Nodes = append(out.Nodes, kr)
-		out.TotalCount++
+			mu.Lock()
+			defer mu.Unlock()
+			out.Nodes = append(out.Nodes, kr)
+			out.TotalCount++
+		}()
 	}
+	wg.Wait()
 
 	sort.Stable(out)
 	return *out, nil

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -1245,7 +1245,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxr := model.GetCompositeResource(&unstructured.Unstructured{})
+	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -571,11 +571,11 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 
 	kra := &unstructured.Unstructured{}
 	kra.SetKind("A")
-	gkra, _ := model.GetKubernetesResource(kra)
+	gkra, _ := model.GetKubernetesResource(kra, model.SelectAll)
 
 	krb := &unstructured.Unstructured{}
 	krb.SetKind("B")
-	gkrb, _ := model.GetKubernetesResource(krb)
+	gkrb, _ := model.GetKubernetesResource(krb, model.SelectAll)
 
 	krc := &unstructured.Unstructured{}
 	krc.SetKind("C")

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -74,7 +74,7 @@ func TestCompositeResourceDefinition(t *testing.T) {
 		},
 	}
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -229,7 +229,7 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -994,7 +994,7 @@ func TestCompositeResourceClaimDefinition(t *testing.T) {
 		},
 	}
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,
@@ -1149,7 +1149,7 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
 	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -438,7 +438,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SelectAll)
+	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -551,7 +551,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -628,11 +628,11 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 
 	kra := &unstructured.Unstructured{}
 	kra.SetKind("A")
-	gkra, _ := model.GetKubernetesResource(kra, model.SelectAll)
+	gkra, _ := model.GetKubernetesResource(kra, model.SkipFields(model.FieldUnstructured))
 
 	krb := &unstructured.Unstructured{}
 	krb.SetKind("B")
-	gkrb, _ := model.GetKubernetesResource(krb, model.SelectAll)
+	gkrb, _ := model.GetKubernetesResource(krb, model.SkipFields(model.FieldUnstructured))
 
 	krc := &unstructured.Unstructured{}
 	krc.SetKind("C")
@@ -764,7 +764,7 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1383,7 +1383,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SelectAll)
+	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -1496,7 +1496,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -381,7 +381,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{})
+	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -226,7 +226,15 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gcmp := model.GetComposition(&extv1.Composition{})
+	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "nodes.unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -313,13 +321,30 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceSpec{
 					CompositionReference: &corev1.ObjectReference{},
 				},
 			},
 			want: want{
 				cmp: &gcmp,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the composition we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceSpec{
+					CompositionReference: &corev1.ObjectReference{},
+				},
+			},
+			want: want{
+				cmp: &gcmpSkipUnstructured,
 			},
 		},
 	}
@@ -1121,7 +1146,15 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gcmp := model.GetComposition(&extv1.Composition{})
+	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "nodes.unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -1208,13 +1241,30 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceClaimSpec{
 					CompositionReference: &corev1.ObjectReference{},
 				},
 			},
 			want: want{
 				cmp: &gcmp,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the composition we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceClaimSpec{
+					CompositionReference: &corev1.ObjectReference{},
+				},
+			},
+			want: want{
+				cmp: &gcmpSkipUnstructured,
 			},
 		},
 	}

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	extv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 
@@ -58,7 +59,7 @@ func TestCompositeResourceDefinition(t *testing.T) {
 		},
 	}
 	gxrd := model.GetCompositeResourceDefinition(&xrd, model.SelectAll)
-	gxrdSkipUnstructured := model.GetCompositeResourceDefinition(&xrd, model.SkipFields(model.FieldUnstructured))
+	gxrdSkipUnstructured := model.GetCompositeResourceDefinition(&xrd, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	otherGroup := extv1.CompositeResourceDefinition{
 		Spec: extv1.CompositeResourceDefinitionSpec{
@@ -215,7 +216,7 @@ func TestCompositeResourceDefinition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -227,7 +228,7 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
-	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -364,7 +365,7 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -427,7 +428,7 @@ func TestCompositeResourceSpecCompositionRef(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -438,7 +439,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
+	gxrc := model.GetCompositeResourceClaim(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx context.Context
@@ -551,7 +552,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -616,7 +617,7 @@ func TestCompositeResourceSpecClaimRef(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ClaimRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ClaimRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -628,11 +629,11 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 
 	kra := &unstructured.Unstructured{}
 	kra.SetKind("A")
-	gkra, _ := model.GetKubernetesResource(kra, model.SkipFields(model.FieldUnstructured))
+	gkra, _ := model.GetKubernetesResource(kra, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	krb := &unstructured.Unstructured{}
 	krb.SetKind("B")
-	gkrb, _ := model.GetKubernetesResource(krb, model.SkipFields(model.FieldUnstructured))
+	gkrb, _ := model.GetKubernetesResource(krb, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	krc := &unstructured.Unstructured{}
 	krc.SetKind("C")
@@ -764,7 +765,7 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -776,7 +777,7 @@ func TestCompositeResourceSpecConnectionSecret(t *testing.T) {
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
 	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
-	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -913,7 +914,7 @@ func TestCompositeResourceSpecConnectionSecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -979,7 +980,7 @@ func TestCompositeResourceSpecWriteConnectionSecretToReference(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -996,7 +997,7 @@ func TestCompositeResourceClaimDefinition(t *testing.T) {
 		},
 	}
 	gxrd := model.GetCompositeResourceDefinition(&xrd, model.SelectAll)
-	gxrdSkipUnstructured := model.GetCompositeResourceDefinition(&xrd, model.SkipFields(model.FieldUnstructured))
+	gxrdSkipUnstructured := model.GetCompositeResourceDefinition(&xrd, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	noClaim := extv1.CompositeResourceDefinition{
 		Spec: extv1.CompositeResourceDefinitionSpec{
@@ -1160,7 +1161,7 @@ func TestCompositeResourceClaimDefinition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1172,7 +1173,7 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
-	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -1309,7 +1310,7 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1372,7 +1373,7 @@ func TestCompositeResourceClaimSpecCompositionRef(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1383,7 +1384,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
+	gxr := model.GetCompositeResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx context.Context
@@ -1496,7 +1497,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1561,7 +1562,7 @@ func TestCompositeResourceClaimSpecResourceReference(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ResourceRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ResourceRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1573,7 +1574,7 @@ func TestCompositeResourceClaimSpecConnectionSecret(t *testing.T) {
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
 	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
-	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -1710,7 +1711,7 @@ func TestCompositeResourceClaimSpecConnectionSecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1776,7 +1777,7 @@ func TestCompositeResourceClaimSpecWriteConnectionSecretToReference(t *testing.T
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -775,7 +775,15 @@ func TestCompositeResourceSpecConnectionSecret(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gsec := model.GetSecret(&corev1.Secret{})
+	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -862,13 +870,30 @@ func TestCompositeResourceSpecConnectionSecret(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceSpec{
 					WriteConnectionSecretToReference: &xpv1.SecretReference{},
 				},
 			},
 			want: want{
 				sec: &gsec,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the secret we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceSpec{
+					WriteConnectionSecretToReference: &xpv1.SecretReference{},
+				},
+			},
+			want: want{
+				sec: &gsecSkipUnstructured,
 			},
 		},
 	}
@@ -1547,7 +1572,15 @@ func TestCompositeResourceClaimSpecConnectionSecret(t *testing.T) {
 	errBoom := errors.New("boom")
 	errNotFound := apierrors.NewNotFound(schema.GroupResource{}, "somename")
 
-	gsec := model.GetSecret(&corev1.Secret{})
+	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+
+	// A selection set with "unstructured" field included.
+	gselectWithUnstructured := ast.SelectionSet{
+		&ast.Field{
+			Name: model.FieldUnstructured,
+		},
+	}
 
 	type args struct {
 		ctx context.Context
@@ -1634,13 +1667,30 @@ func TestCompositeResourceClaimSpecConnectionSecret(t *testing.T) {
 				}, nil
 			}),
 			args: args{
-				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				ctx: graphql.WithResponseContext(testContext(gselectWithUnstructured), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
 				obj: &model.CompositeResourceClaimSpec{
 					WriteConnectionSecretToReference: &xpv1.SecretReference{},
 				},
 			},
 			want: want{
 				sec: &gsec,
+			},
+		},
+		"SuccessSkipUnstructured": {
+			reason: "If we can get and model the secret we should return it without the unstructured field.",
+			clients: ClientCacheFn(func(_ auth.Credentials, _ ...clients.GetOption) (client.Client, error) {
+				return &test.MockClient{
+					MockGet: test.NewMockGetFn(nil),
+				}, nil
+			}),
+			args: args{
+				ctx: graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter, graphql.DefaultRecover),
+				obj: &model.CompositeResourceClaimSpec{
+					WriteConnectionSecretToReference: &xpv1.SecretReference{},
+				},
+			},
+			want: want{
+				sec: &gsecSkipUnstructured,
 			},
 		},
 	}

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -190,7 +190,7 @@ func (r *configurationRevisionStatus) Objects(ctx context.Context, obj *model.Co
 				continue
 			}
 
-			out.Nodes = append(out.Nodes, model.GetComposition(cmp))
+			out.Nodes = append(out.Nodes, model.GetComposition(cmp, selectedFields))
 			out.TotalCount++
 		}
 	}

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -163,6 +163,7 @@ func (r *configurationRevisionStatus) Objects(ctx context.Context, obj *model.Co
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ObjectRefs)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for _, ref := range obj.ObjectRefs {
 		// Crossplane lints configuration packages to ensure they only contain XRDs and Compositions
@@ -180,7 +181,7 @@ func (r *configurationRevisionStatus) Objects(ctx context.Context, obj *model.Co
 				continue
 			}
 
-			out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd))
+			out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd, selectedFields))
 			out.TotalCount++
 		case extv1.CompositionKind:
 			cmp := &extv1.Composition{}

--- a/internal/graph/resolvers/configuration.go
+++ b/internal/graph/resolvers/configuration.go
@@ -72,6 +72,7 @@ func (r *configuration) Revisions(ctx context.Context, obj *model.Configuration)
 	out := &model.ConfigurationRevisionConnection{
 		Nodes: make([]model.ConfigurationRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		cr := in.Items[i] // So we don't take the address of a range variable.
@@ -83,7 +84,7 @@ func (r *configuration) Revisions(ctx context.Context, obj *model.Configuration)
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&cr))
+		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&cr, selectedFields))
 		out.TotalCount++
 	}
 
@@ -123,7 +124,7 @@ func (r *configuration) ActiveRevision(ctx context.Context, obj *model.Configura
 			continue
 		}
 
-		out := model.GetConfigurationRevision(&cr)
+		out := model.GetConfigurationRevision(&cr, GetSelectedFields(ctx))
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/configuration_test.go
+++ b/internal/graph/resolvers/configuration_test.go
@@ -239,7 +239,7 @@ func TestConfigurationActiveRevision(t *testing.T) {
 		Spec:       pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 
-	// A selection set with "nodes.unstructured" field included.
+	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
 			Name: model.FieldUnstructured,

--- a/internal/graph/resolvers/configuration_test.go
+++ b/internal/graph/resolvers/configuration_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	extv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
@@ -61,7 +62,7 @@ func TestConfigurationRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetConfigurationRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetConfigurationRevision(&active, model.SkipFields(model.FieldUnstructured))
+	gactiveSkipUnstructured := model.GetConfigurationRevision(&active, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ConfigurationRevision we control, but that is inactive.
 	inactive := pkgv1.ConfigurationRevision{
@@ -72,7 +73,7 @@ func TestConfigurationRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetConfigurationRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetConfigurationRevision(&inactive, model.SkipFields(model.FieldUnstructured))
+	ginactiveSkipUnstructured := model.GetConfigurationRevision(&inactive, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ConfigurationRevision which we do not control.
 	other := pkgv1.ConfigurationRevision{ObjectMeta: metav1.ObjectMeta{Name: "not-ours"}}
@@ -201,7 +202,7 @@ func TestConfigurationRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -222,7 +223,7 @@ func TestConfigurationActiveRevision(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetConfigurationRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetConfigurationRevision(&active, model.SkipFields(model.FieldUnstructured))
+	gactiveSkipUnstructured := model.GetConfigurationRevision(&active, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ConfigurationRevision we control, but that is inactive.
 	inactive := pkgv1.ConfigurationRevision{
@@ -374,7 +375,7 @@ func TestConfigurationActiveRevision(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -385,9 +386,9 @@ func TestConfigurationRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	gxrd := model.GetCompositeResourceDefinition(&extv1.CompositeResourceDefinition{}, model.SelectAll)
-	gxrdSkipUnstructured := model.GetCompositeResourceDefinition(&extv1.CompositeResourceDefinition{}, model.SkipFields(model.FieldUnstructured))
+	gxrdSkipUnstructured := model.GetCompositeResourceDefinition(&extv1.CompositeResourceDefinition{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	gcmp := model.GetComposition(&extv1.Composition{}, model.SelectAll)
-	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured))
+	gcmpSkipUnstructured := model.GetComposition(&extv1.Composition{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -626,7 +627,7 @@ func TestConfigurationRevisionStatusObjects(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/event.go
+++ b/internal/graph/resolvers/event.go
@@ -54,6 +54,7 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (mode
 		graphql.AddError(ctx, errors.Wrap(err, errListEvents))
 		return model.EventConnection{}, nil
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	// If no involved object was supplied we want to fetch all events. This may
 	// include Kubernetes events that don't pertain to Crossplane.
@@ -63,7 +64,7 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (mode
 			TotalCount: len(in.Items),
 		}
 		for i := range in.Items {
-			out.Nodes = append(out.Nodes, model.GetEvent(&in.Items[i]))
+			out.Nodes = append(out.Nodes, model.GetEvent(&in.Items[i], selectedFields))
 		}
 
 		sort.Stable(sort.Reverse(out))
@@ -87,7 +88,7 @@ func (r *events) Resolve(ctx context.Context, obj *corev1.ObjectReference) (mode
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetEvent(e))
+		out.Nodes = append(out.Nodes, model.GetEvent(e, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/event.go
+++ b/internal/graph/resolvers/event.go
@@ -153,7 +153,7 @@ func (r *event) InvolvedObject(ctx context.Context, obj *model.Event) (model.Kub
 		return nil, nil
 	}
 
-	out, err := model.GetKubernetesResource(u)
+	out, err := model.GetKubernetesResource(u, GetSelectedFields(ctx))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelInvolved))
 		return nil, nil

--- a/internal/graph/resolvers/event_test.go
+++ b/internal/graph/resolvers/event_test.go
@@ -270,7 +270,7 @@ var _ generated.EventResolver = &event{}
 func TestEventInvolvedObject(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{})
+	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/event_test.go
+++ b/internal/graph/resolvers/event_test.go
@@ -324,7 +324,7 @@ var _ generated.EventResolver = &event{}
 func TestEventInvolvedObject(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SelectAll)
+	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -412,7 +412,7 @@ func TestEventInvolvedObject(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/event_test.go
+++ b/internal/graph/resolvers/event_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -144,7 +145,7 @@ func TestEvent(t *testing.T) {
 			},
 			want: want{
 				ec: model.EventConnection{
-					Nodes:      []model.Event{model.GetEvent(&related, model.SkipFields(model.FieldUnstructured)), model.GetEvent(&unrelated, model.SkipFields(model.FieldUnstructured))},
+					Nodes:      []model.Event{model.GetEvent(&related, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath)), model.GetEvent(&unrelated, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))},
 					TotalCount: 2,
 				},
 			},
@@ -186,7 +187,7 @@ func TestEvent(t *testing.T) {
 			},
 			want: want{
 				ec: model.EventConnection{
-					Nodes:      []model.Event{model.GetEvent(&related, model.SkipFields(model.FieldUnstructured))},
+					Nodes:      []model.Event{model.GetEvent(&related, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))},
 					TotalCount: 1,
 				},
 			},
@@ -208,7 +209,7 @@ func TestEvent(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Resolve(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ec, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ec, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Resolve(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -324,7 +325,7 @@ var _ generated.EventResolver = &event{}
 func TestEventInvolvedObject(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
+	gu, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx context.Context
@@ -412,7 +413,7 @@ func TestEventInvolvedObject(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/managed.go
+++ b/internal/graph/resolvers/managed.go
@@ -81,6 +81,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 		graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
 		return nil, nil
 	}
+	selectedFields := GetSelectedFields(ctx)
 
 	// We didn't find the CRD we were looking for, list all CRDs and see if we
 	// can find the matching one.
@@ -102,7 +103,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 				continue
 			}
 
-			out := model.GetCustomResourceDefinition(&crd)
+			out := model.GetCustomResourceDefinition(&crd, selectedFields)
 			return &out, nil
 		}
 	}
@@ -110,7 +111,7 @@ func (r *managedResource) Definition(ctx context.Context, obj *model.ManagedReso
 	// We found a CRD, let's double check the Group and Kind match our
 	// expectations.
 	if in.GetSpecGroup() == gv.Group && in.GetSpecNames().Kind == obj.Kind {
-		out := model.GetCustomResourceDefinition(in)
+		out := model.GetCustomResourceDefinition(in, selectedFields)
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/managed.go
+++ b/internal/graph/resolvers/managed.go
@@ -147,6 +147,6 @@ func (r *managedResourceSpec) ConnectionSecret(ctx context.Context, obj *model.M
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -59,8 +59,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
+	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured))
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured))
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")
@@ -232,7 +232,6 @@ func TestManagedResourceDefinition(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -58,8 +58,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd)
-	dcrd := model.GetCustomResourceDefinition((crdDifferingPlural))
+	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -59,8 +60,8 @@ func TestManagedResourceDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured))
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured))
+	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")
@@ -231,7 +232,7 @@ func TestManagedResourceDefinition(t *testing.T) {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -243,7 +244,7 @@ func TestManagedResourceSpecConnectionSecret(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
-	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -363,7 +364,7 @@ func TestManagedResourceSpecConnectionSecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/mutation.go
+++ b/internal/graph/resolvers/mutation.go
@@ -102,7 +102,7 @@ func (r *mutation) CreateKubernetesResource(ctx context.Context, input model.Cre
 		return model.CreateKubernetesResourcePayload{}, nil
 	}
 
-	kr, err := model.GetKubernetesResource(u)
+	kr, err := model.GetKubernetesResource(u, GetSelectedFields(ctx).Sub("resource"))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return model.CreateKubernetesResourcePayload{}, nil
@@ -153,7 +153,7 @@ func (r *mutation) UpdateKubernetesResource(ctx context.Context, id model.Refere
 		return model.UpdateKubernetesResourcePayload{}, nil
 	}
 
-	kr, err := model.GetKubernetesResource(u)
+	kr, err := model.GetKubernetesResource(u, GetSelectedFields(ctx).Sub("resource"))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return model.UpdateKubernetesResourcePayload{}, nil
@@ -182,7 +182,7 @@ func (r *mutation) DeleteKubernetesResource(ctx context.Context, id model.Refere
 		return model.DeleteKubernetesResourcePayload{}, nil //nolint:nilerr // IgnoreNotFound appears to trigger this linter.
 	}
 
-	kr, err := model.GetKubernetesResource(u)
+	kr, err := model.GetKubernetesResource(u, GetSelectedFields(ctx).Sub("resource"))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return model.DeleteKubernetesResourcePayload{}, nil

--- a/internal/graph/resolvers/mutation_test.go
+++ b/internal/graph/resolvers/mutation_test.go
@@ -101,7 +101,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u)
+	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
 
 	type args struct {
 		ctx   context.Context
@@ -268,7 +268,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u)
+	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
 
 	type args struct {
 		ctx   context.Context
@@ -444,7 +444,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 	u.SetKind("Example")
 	u.SetName("example")
 
-	kr, _ := model.GetKubernetesResource(u)
+	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
 
 	cases := map[string]struct {
 		reason  string

--- a/internal/graph/resolvers/mutation_test.go
+++ b/internal/graph/resolvers/mutation_test.go
@@ -101,7 +101,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx   context.Context
@@ -246,7 +246,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -268,7 +268,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx   context.Context
@@ -420,7 +420,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -444,7 +444,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 	u.SetKind("Example")
 	u.SetName("example")
 
-	kr, _ := model.GetKubernetesResource(u, model.SelectAll)
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
 
 	cases := map[string]struct {
 		reason  string
@@ -522,7 +522,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/mutation_test.go
+++ b/internal/graph/resolvers/mutation_test.go
@@ -101,7 +101,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx   context.Context
@@ -246,7 +246,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -268,7 +268,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 	u.SetName("example")
 	uj, _ := json.Marshal(u)
 
-	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx   context.Context
@@ -420,7 +420,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -444,7 +444,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 	u.SetKind("Example")
 	u.SetName("example")
 
-	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured))
+	kr, _ := model.GetKubernetesResource(u, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	cases := map[string]struct {
 		reason  string
@@ -522,7 +522,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/objectmeta.go
+++ b/internal/graph/resolvers/objectmeta.go
@@ -48,6 +48,7 @@ func (r *objectMeta) Owners(ctx context.Context, obj *model.ObjectMeta) (model.O
 	}
 
 	owners := make([]model.Owner, 0, len(obj.OwnerReferences))
+	selectedFields := GetSelectedFields(ctx).Sub("nodes.resource")
 	for _, ref := range obj.OwnerReferences {
 		u := &kunstructured.Unstructured{}
 		u.SetAPIVersion(ref.APIVersion)
@@ -59,7 +60,7 @@ func (r *objectMeta) Owners(ctx context.Context, obj *model.ObjectMeta) (model.O
 			continue
 		}
 
-		kr, err := model.GetKubernetesResource(u)
+		kr, err := model.GetKubernetesResource(u, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelOwner))
 			continue
@@ -82,6 +83,7 @@ func (r *objectMeta) Controller(ctx context.Context, obj *model.ObjectMeta) (mod
 		return nil, nil
 	}
 
+	selectedFields := GetSelectedFields(ctx)
 	for _, ref := range obj.OwnerReferences {
 		if !pointer.BoolDeref(ref.Controller, false) {
 			continue
@@ -97,7 +99,7 @@ func (r *objectMeta) Controller(ctx context.Context, obj *model.ObjectMeta) (mod
 			return nil, nil
 		}
 
-		kr, err := model.GetKubernetesResource(u)
+		kr, err := model.GetKubernetesResource(u, selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelOwner))
 			return nil, nil

--- a/internal/graph/resolvers/objectmeta_test.go
+++ b/internal/graph/resolvers/objectmeta_test.go
@@ -50,7 +50,7 @@ func TestObjectMetaOwners(t *testing.T) {
 	own := unstructured.Unstructured{}
 	own.SetAPIVersion("example.org/v1")
 	own.SetKind("AnOwner")
-	gown, _ := model.GetKubernetesResource(&own)
+	gown, _ := model.GetKubernetesResource(&own, model.SelectAll)
 
 	type args struct {
 		ctx context.Context
@@ -156,7 +156,7 @@ func TestObjectMetaController(t *testing.T) {
 	ctrl := unstructured.Unstructured{}
 	ctrl.SetAPIVersion("example.org/v1")
 	ctrl.SetKind("TheController")
-	gctrl, _ := model.GetKubernetesResource(&ctrl)
+	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SelectAll)
 
 	// An owner
 	own := unstructured.Unstructured{}

--- a/internal/graph/resolvers/objectmeta_test.go
+++ b/internal/graph/resolvers/objectmeta_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -50,7 +51,7 @@ func TestObjectMetaOwners(t *testing.T) {
 	own := unstructured.Unstructured{}
 	own.SetAPIVersion("example.org/v1")
 	own.SetKind("AnOwner")
-	gown, _ := model.GetKubernetesResource(&own, model.SkipFields(model.FieldUnstructured))
+	gown, _ := model.GetKubernetesResource(&own, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx context.Context
@@ -140,7 +141,7 @@ func TestObjectMetaOwners(t *testing.T) {
 				t.Errorf("\n%s\nq.Owners(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.oc, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Owners(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -155,7 +156,7 @@ func TestObjectMetaController(t *testing.T) {
 	ctrl := unstructured.Unstructured{}
 	ctrl.SetAPIVersion("example.org/v1")
 	ctrl.SetKind("TheController")
-	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SkipFields(model.FieldUnstructured))
+	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// An owner
 	own := unstructured.Unstructured{}
@@ -284,7 +285,7 @@ func TestObjectMetaController(t *testing.T) {
 				t.Errorf("\n%s\nq.Controller(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.kr, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Controller(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/objectmeta_test.go
+++ b/internal/graph/resolvers/objectmeta_test.go
@@ -50,7 +50,7 @@ func TestObjectMetaOwners(t *testing.T) {
 	own := unstructured.Unstructured{}
 	own.SetAPIVersion("example.org/v1")
 	own.SetKind("AnOwner")
-	gown, _ := model.GetKubernetesResource(&own, model.SelectAll)
+	gown, _ := model.GetKubernetesResource(&own, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -141,7 +141,6 @@ func TestObjectMetaOwners(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.oc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Owners(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -156,7 +155,7 @@ func TestObjectMetaController(t *testing.T) {
 	ctrl := unstructured.Unstructured{}
 	ctrl.SetAPIVersion("example.org/v1")
 	ctrl.SetKind("TheController")
-	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SelectAll)
+	gctrl, _ := model.GetKubernetesResource(&ctrl, model.SkipFields(model.FieldUnstructured))
 
 	// An owner
 	own := unstructured.Unstructured{}
@@ -286,7 +285,6 @@ func TestObjectMetaController(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.kr, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Controller(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -164,6 +164,7 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ObjectRefs)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for _, ref := range obj.ObjectRefs {
 		// Crossplane lints provider packages to ensure they only contain CRDs,
@@ -182,7 +183,7 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd))
+		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -72,6 +72,7 @@ func (r *provider) Revisions(ctx context.Context, obj *model.Provider) (model.Pr
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
@@ -83,7 +84,7 @@ func (r *provider) Revisions(ctx context.Context, obj *model.Provider) (model.Pr
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr))
+		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr, selectedFields))
 		out.TotalCount++
 	}
 
@@ -108,6 +109,7 @@ func (r *provider) ActiveRevision(ctx context.Context, obj *model.Provider) (*mo
 		return nil, nil
 	}
 
+	selectedFields := GetSelectedFields(ctx)
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
 
@@ -123,7 +125,7 @@ func (r *provider) ActiveRevision(ctx context.Context, obj *model.Provider) (*mo
 			continue
 		}
 
-		out := model.GetProviderRevision(&pr)
+		out := model.GetProviderRevision(&pr, selectedFields)
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -72,7 +72,7 @@ func (r *provider) Revisions(ctx context.Context, obj *model.Provider) (model.Pr
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -385,7 +385,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{})
+	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SelectAll)
 
 	type args struct {
 		ctx context.Context

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -62,7 +62,7 @@ func TestProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields("unstructured"))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -73,7 +73,7 @@ func TestProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetProviderRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields("unstructured"))
+	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision which we do not control.
 	other := pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "not-ours"}}
@@ -81,9 +81,9 @@ func TestProviderRevisions(t *testing.T) {
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
-			Name: "nodes",
+			Name: model.FieldNodes,
 			SelectionSet: ast.SelectionSet{
-				&ast.Field{Name: "unstructured"},
+				&ast.Field{Name: model.FieldUnstructured},
 			},
 		},
 	}
@@ -222,7 +222,7 @@ func TestProviderActiveRevision(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields("unstructured"))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -239,10 +239,10 @@ func TestProviderActiveRevision(t *testing.T) {
 		Spec:       pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 
-	// A selection set with "unstructured" field included.
+	// A selection set with fieldUnstructured field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
-			Name: "unstructured",
+			Name: model.FieldUnstructured,
 		},
 	}
 

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
@@ -62,7 +63,7 @@ func TestProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -73,7 +74,7 @@ func TestProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetProviderRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured))
+	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ProviderRevision which we do not control.
 	other := pkgv1.ProviderRevision{ObjectMeta: metav1.ObjectMeta{Name: "not-ours"}}
@@ -201,7 +202,7 @@ func TestProviderRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -222,7 +223,7 @@ func TestProviderActiveRevision(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -375,7 +376,7 @@ func TestProviderActiveRevision(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -385,7 +386,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SkipFields(model.FieldUnstructured))
+	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx context.Context
@@ -514,7 +515,7 @@ func TestProviderRevisionStatusObjects(t *testing.T) {
 				t.Errorf("\n%s\ns.Objects(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.krc, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -385,7 +385,7 @@ func TestProviderActiveRevision(t *testing.T) {
 func TestProviderRevisionStatusObjects(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SelectAll)
+	gcrd := model.GetCustomResourceDefinition(&xunstructured.CustomResourceDefinition{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -515,7 +515,6 @@ func TestProviderRevisionStatusObjects(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.krc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/providerconfig.go
+++ b/internal/graph/resolvers/providerconfig.go
@@ -101,7 +101,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 				continue
 			}
 
-			out := model.GetCustomResourceDefinition(&crd)
+			out := model.GetCustomResourceDefinition(&crd, GetSelectedFields(ctx))
 			return &out, nil
 		}
 	}
@@ -109,7 +109,7 @@ func (r *providerConfig) Definition(ctx context.Context, obj *model.ProviderConf
 	// We found a CRD, let's double check the Group and Kind match our
 	// expectations.
 	if in.GetSpecGroup() == gv.Group && in.GetSpecNames().Kind == obj.Kind {
-		out := model.GetCustomResourceDefinition(in)
+		out := model.GetCustomResourceDefinition(in, GetSelectedFields(ctx))
 		return &out, nil
 	}
 

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -56,8 +56,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
+	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured))
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured))
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")
@@ -229,7 +229,6 @@ func TestProviderConfigDefinition(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -29,6 +29,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -56,8 +57,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured))
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured))
+	gcrd := model.GetCustomResourceDefinition(crd, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")
@@ -228,7 +229,7 @@ func TestProviderConfigDefinition(t *testing.T) {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -56,8 +56,8 @@ func TestProviderConfigDefinition(t *testing.T) {
 	crdDifferingPlural.SetSpecGroup("example.org")
 	crdDifferingPlural.SetSpecNames(kextv1.CustomResourceDefinitionNames{Kind: "Example", Plural: "Examplii"})
 
-	gcrd := model.GetCustomResourceDefinition(crd)
-	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural)
+	gcrd := model.GetCustomResourceDefinition(crd, model.SelectAll)
+	dcrd := model.GetCustomResourceDefinition(crdDifferingPlural, model.SelectAll)
 
 	otherGroup := unstructured.NewCRD()
 	otherGroup.SetSpecGroup("example.net")

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -384,9 +384,10 @@ func (r *query) Configurations(ctx context.Context) (model.ConfigurationConnecti
 		Nodes:      make([]model.Configuration, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
-		out.Nodes = append(out.Nodes, model.GetConfiguration(&in.Items[i]))
+		out.Nodes = append(out.Nodes, model.GetConfiguration(&in.Items[i], selectedFields))
 	}
 
 	sort.Stable(out)

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -500,6 +500,7 @@ func (r *query) Compositions(ctx context.Context, revision *model.ReferenceID, d
 	out := &model.CompositionConnection{
 		Nodes: make([]model.Composition, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		cmp := &in.Items[i]
@@ -514,7 +515,7 @@ func (r *query) Compositions(ctx context.Context, revision *model.ReferenceID, d
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetComposition(cmp))
+		out.Nodes = append(out.Nodes, model.GetComposition(cmp, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -135,7 +135,7 @@ func (r *query) KubernetesResource(ctx context.Context, id model.ReferenceID) (m
 		return nil, nil
 	}
 
-	out, err := model.GetKubernetesResource(u)
+	out, err := model.GetKubernetesResource(u, GetSelectedFields(ctx))
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 		return nil, nil
@@ -176,9 +176,10 @@ func (r *query) KubernetesResources(ctx context.Context, apiVersion, kind string
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(in.Items)),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
-		kr, err := model.GetKubernetesResource(&in.Items[i])
+		kr, err := model.GetKubernetesResource(&in.Items[i], selectedFields)
 		if err != nil {
 			graphql.AddError(ctx, errors.Wrap(err, errModelResource))
 			continue
@@ -301,6 +302,7 @@ func (r *query) ProviderRevisions(ctx context.Context, provider *model.Reference
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub("nodes")
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
@@ -315,7 +317,7 @@ func (r *query) ProviderRevisions(ctx context.Context, provider *model.Reference
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr))
+		out.Nodes = append(out.Nodes, model.GetProviderRevision(&pr, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -248,7 +248,7 @@ func (r *query) ConfigMap(ctx context.Context, namespace, name string) (*model.C
 		return nil, nil
 	}
 
-	out := model.GetConfigMap(cm)
+	out := model.GetConfigMap(cm, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -176,7 +176,7 @@ func (r *query) KubernetesResources(ctx context.Context, apiVersion, kind string
 	out := &model.KubernetesResourceConnection{
 		Nodes: make([]model.KubernetesResource, 0, len(in.Items)),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		kr, err := model.GetKubernetesResource(&in.Items[i], selectedFields)
@@ -302,7 +302,7 @@ func (r *query) ProviderRevisions(ctx context.Context, provider *model.Reference
 	out := &model.ProviderRevisionConnection{
 		Nodes: make([]model.ProviderRevision, 0),
 	}
-	selectedFields := GetSelectedFields(ctx).Sub("nodes")
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -226,7 +226,7 @@ func (r *query) Secret(ctx context.Context, namespace, name string) (*model.Secr
 		return nil, nil
 	}
 
-	out := model.GetSecret(s)
+	out := model.GetSecret(s, GetSelectedFields(ctx))
 	return &out, nil
 }
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -17,6 +17,7 @@ package resolvers
 import (
 	"context"
 	"sort"
+	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ type query struct {
 }
 
 // Recursively collect `CrossplaneResourceTreeNode`s from the given KubernetesResource
-func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResource, parentID *model.ReferenceID) ([]model.CrossplaneResourceTreeNode, error) { //nolint:gocyclo
+func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResource, parentID *model.ReferenceID) []model.CrossplaneResourceTreeNode { //nolint:gocyclo
 	// This isn't _really_ that complex; it's a long but simple switch.
 
 	switch typedRes := res.(type) {
@@ -63,19 +64,32 @@ func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResour
 			GetSelectedFields(ctx).Sub("nodes.resource").Pre(model.FieldNodes),
 		), &typedRes.Spec)
 		if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-			return nil, err
+			return nil
 		}
 
-		for _, childRes := range resources.Nodes {
-			childList, err := r.getAllDescendant(ctx, childRes, &typedRes.ID)
-			if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-				return nil, err
-			}
+		// Collect all concurrently.
+		var (
+			wg sync.WaitGroup
+		)
+		childLists := make([][]model.CrossplaneResourceTreeNode, len(resources.Nodes))
+		for i, childRes := range resources.Nodes {
+			i, childRes := i, childRes // So we don't capture the loop variable.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				childLists[i] = r.getAllDescendant(ctx, childRes, &typedRes.ID)
+			}()
+		}
+		wg.Wait()
 
+		if len(graphql.GetErrors(ctx)) > 0 {
+			return nil
+		}
+
+		for _, childList := range childLists {
 			list = append(list, childList...)
 		}
-
-		return list, nil
+		return list
 	case model.CompositeResourceClaim:
 		list := []model.CrossplaneResourceTreeNode{{ParentID: parentID, Resource: typedRes}}
 
@@ -84,21 +98,21 @@ func (r *query) getAllDescendant(ctx context.Context, res model.KubernetesResour
 			GetSelectedFields(ctx).Sub("nodes.resource"),
 		), &typedRes.Spec)
 		if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-			return nil, err
+			return nil
 		}
 
 		if composite == nil {
-			return list, nil
+			return list
 		}
 
-		childList, err := r.getAllDescendant(ctx, *composite, &typedRes.ID)
+		childList := r.getAllDescendant(ctx, *composite, &typedRes.ID)
 		if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-			return nil, err
+			return nil
 		}
 
-		return append(list, childList...), nil
+		return append(list, childList...)
 	default:
-		return []model.CrossplaneResourceTreeNode{{ParentID: parentID, Resource: typedRes}}, nil
+		return []model.CrossplaneResourceTreeNode{{ParentID: parentID, Resource: typedRes}}
 	}
 }
 
@@ -116,9 +130,9 @@ func (r *query) CrossplaneResourceTree(ctx context.Context, id model.ReferenceID
 		return model.CrossplaneResourceTreeConnection{}, err
 	}
 
-	list, err := r.getAllDescendant(ctx, rootRes, nil)
-	if err != nil || len(graphql.GetErrors(ctx)) > 0 {
-		return model.CrossplaneResourceTreeConnection{}, err
+	list := r.getAllDescendant(ctx, rootRes, nil)
+	if len(graphql.GetErrors(ctx)) > 0 {
+		return model.CrossplaneResourceTreeConnection{}, nil
 	}
 
 	return model.CrossplaneResourceTreeConnection{Nodes: list, TotalCount: len(list)}, nil

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -457,6 +457,7 @@ func (r *query) CompositeResourceDefinitions(ctx context.Context, revision *mode
 	out := &model.CompositeResourceDefinitionConnection{
 		Nodes: make([]model.CompositeResourceDefinition, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		xrd := &in.Items[i]
@@ -471,7 +472,7 @@ func (r *query) CompositeResourceDefinitions(ctx context.Context, revision *mode
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd))
+		out.Nodes = append(out.Nodes, model.GetCompositeResourceDefinition(xrd, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -346,6 +346,7 @@ func (r *query) CustomResourceDefinitions(ctx context.Context, revision *model.R
 	out := &model.CustomResourceDefinitionConnection{
 		Nodes: make([]model.CustomResourceDefinition, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		xrd := &xunstructured.CustomResourceDefinition{Unstructured: in.Items[i]}
@@ -355,7 +356,7 @@ func (r *query) CustomResourceDefinitions(ctx context.Context, revision *model.R
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(xrd))
+		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(xrd, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -414,6 +414,7 @@ func (r *query) ConfigurationRevisions(ctx context.Context, configuration *model
 	out := &model.ConfigurationRevisionConnection{
 		Nodes: make([]model.ConfigurationRevision, 0),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
 		pr := in.Items[i] // So we don't take the address of a range variable.
@@ -428,7 +429,7 @@ func (r *query) ConfigurationRevisions(ctx context.Context, configuration *model
 			continue
 		}
 
-		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&pr))
+		out.Nodes = append(out.Nodes, model.GetConfigurationRevision(&pr, selectedFields))
 		out.TotalCount++
 	}
 

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -273,9 +273,10 @@ func (r *query) Providers(ctx context.Context) (model.ProviderConnection, error)
 		Nodes:      make([]model.Provider, 0, len(in.Items)),
 		TotalCount: len(in.Items),
 	}
+	selectedFields := GetSelectedFields(ctx).Sub(model.FieldNodes)
 
 	for i := range in.Items {
-		out.Nodes = append(out.Nodes, model.GetProvider(&in.Items[i]))
+		out.Nodes = append(out.Nodes, model.GetProvider(&in.Items[i], selectedFields))
 	}
 
 	sort.Stable(out)

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -809,7 +809,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields("unstructured"))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -824,7 +824,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetProviderRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields("unstructured"))
+	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured))
 
 	// A ProviderRevision which we do not control.
 	other := pkgv1.ProviderRevision{
@@ -838,15 +838,15 @@ func TestQueryProviderRevisions(t *testing.T) {
 		},
 	}
 	gother := model.GetProviderRevision(&other, model.SelectAll)
-	gotherSkipUnstructured := model.GetProviderRevision(&other, model.SkipFields("unstructured"))
+	gotherSkipUnstructured := model.GetProviderRevision(&other, model.SkipFields(model.FieldUnstructured))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
-			Name: "nodes",
+			Name: model.FieldNodes,
 			SelectionSet: ast.SelectionSet{
 				&ast.Field{
-					Name: "unstructured",
+					Name: model.FieldUnstructured,
 				},
 			},
 		},

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -221,10 +221,7 @@ func TestCrossplaneResourceTree(t *testing.T) {
 			}
 
 			diffOptions := []cmp.Option{
-				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.ManagedResource{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.ProviderConfig{}, "Unstructured"),
+
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
 			}
 
@@ -238,7 +235,7 @@ func TestCrossplaneResourceTree(t *testing.T) {
 func TestQueryKubernetesResource(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gkr, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SelectAll)
+	gkr, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx context.Context
@@ -317,7 +314,7 @@ func TestQueryKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1309,12 +1306,12 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 		},
 	})
 
-	gowned := model.GetCustomResourceDefinition(owned, model.SelectAll)
+	gowned := model.GetCustomResourceDefinition(owned, model.SkipFields(model.FieldUnstructured))
 
 	dangler := xunstructured.NewCRD()
 	dangler.SetName("coolconfig")
 
-	gdangler := model.GetCustomResourceDefinition(dangler, model.SelectAll)
+	gdangler := model.GetCustomResourceDefinition(dangler, model.SkipFields(model.FieldUnstructured))
 
 	type args struct {
 		ctx      context.Context
@@ -1437,7 +1434,6 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.xrdc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -222,7 +222,7 @@ func TestCrossplaneResourceTree(t *testing.T) {
 
 			diffOptions := []cmp.Option{
 
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			}
 
 			if diff := cmp.Diff(tc.want.kr, got, diffOptions...); diff != "" {
@@ -235,7 +235,7 @@ func TestCrossplaneResourceTree(t *testing.T) {
 func TestQueryKubernetesResource(t *testing.T) {
 	errBoom := errors.New("boom")
 
-	gkr, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured))
+	gkr, _ := model.GetKubernetesResource(&unstructured.Unstructured{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx context.Context
@@ -314,7 +314,7 @@ func TestQueryKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -326,7 +326,7 @@ func TestQueryKubernetesResources(t *testing.T) {
 
 	kr := unstructured.Unstructured{}
 	gkr, _ := model.GetKubernetesResource(&kr, model.SelectAll)
-	gkrSkipUnstructured, _ := model.GetKubernetesResource(&kr, model.SkipFields(model.FieldUnstructured))
+	gkrSkipUnstructured, _ := model.GetKubernetesResource(&kr, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	group := "example.org"
 	version := "v1"
@@ -613,7 +613,7 @@ func TestQueryKubernetesResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -624,7 +624,7 @@ func TestQuerySecret(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	gsec := model.GetSecret(&corev1.Secret{}, model.SelectAll)
-	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured))
+	gsecSkipUnstructured := model.GetSecret(&corev1.Secret{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -725,7 +725,7 @@ func TestQuerySecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Secret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Secret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -736,7 +736,7 @@ func TestQueryConfigMap(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	gcm := model.GetConfigMap(&corev1.ConfigMap{}, model.SelectAll)
-	gcmSkipUnstructured := model.GetConfigMap(&corev1.ConfigMap{}, model.SkipFields(model.FieldUnstructured))
+	gcmSkipUnstructured := model.GetConfigMap(&corev1.ConfigMap{}, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -837,7 +837,7 @@ func TestQueryConfigMap(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConfigMap(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cm, got, cmp.AllowUnexported(model.ConfigMap{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cm, got, cmp.AllowUnexported(model.ConfigMap{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConfigMap(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -849,7 +849,7 @@ func TestQueryProviders(t *testing.T) {
 
 	p := pkgv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "coolprovider"}}
 	gp := model.GetProvider(&p, model.SelectAll)
-	gpSkipUnstructured := model.GetProvider(&p, model.SkipFields(model.FieldUnstructured))
+	gpSkipUnstructured := model.GetProvider(&p, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -965,7 +965,7 @@ func TestQueryProviders(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Providers(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Providers(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -994,7 +994,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetProviderRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured))
+	gactiveSkipUnstructured := model.GetProviderRevision(&active, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ProviderRevision we control, but that is inactive.
 	inactive := pkgv1.ProviderRevision{
@@ -1009,7 +1009,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetProviderRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured))
+	ginactiveSkipUnstructured := model.GetProviderRevision(&inactive, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ProviderRevision which we do not control.
 	other := pkgv1.ProviderRevision{
@@ -1023,7 +1023,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 		},
 	}
 	gother := model.GetProviderRevision(&other, model.SelectAll)
-	gotherSkipUnstructured := model.GetProviderRevision(&other, model.SkipFields(model.FieldUnstructured))
+	gotherSkipUnstructured := model.GetProviderRevision(&other, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -1249,7 +1249,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1306,12 +1306,12 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 		},
 	})
 
-	gowned := model.GetCustomResourceDefinition(owned, model.SkipFields(model.FieldUnstructured))
+	gowned := model.GetCustomResourceDefinition(owned, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	dangler := xunstructured.NewCRD()
 	dangler.SetName("coolconfig")
 
-	gdangler := model.GetCustomResourceDefinition(dangler, model.SkipFields(model.FieldUnstructured))
+	gdangler := model.GetCustomResourceDefinition(dangler, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	type args struct {
 		ctx      context.Context
@@ -1433,7 +1433,7 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 				t.Errorf("\n%s\nq.Configurations(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
 			if diff := cmp.Diff(tc.want.xrdc, got,
-				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
+				cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{}),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -1446,7 +1446,7 @@ func TestQueryConfigurations(t *testing.T) {
 
 	c := pkgv1.Configuration{ObjectMeta: metav1.ObjectMeta{Name: "coolconfig"}}
 	gc := model.GetConfiguration(&c, model.SelectAll)
-	gcSkipUnstructured := model.GetConfiguration(&c, model.SkipFields(model.FieldUnstructured))
+	gcSkipUnstructured := model.GetConfiguration(&c, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -1562,7 +1562,7 @@ func TestQueryConfigurations(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1591,7 +1591,7 @@ func TestQueryConfigurationRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionActive},
 	}
 	gactive := model.GetConfigurationRevision(&active, model.SelectAll)
-	gactiveSkipUnstructured := model.GetConfigurationRevision(&active, model.SkipFields(model.FieldUnstructured))
+	gactiveSkipUnstructured := model.GetConfigurationRevision(&active, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ConfigurationRevision we control, but that is inactive.
 	inactive := pkgv1.ConfigurationRevision{
@@ -1606,7 +1606,7 @@ func TestQueryConfigurationRevisions(t *testing.T) {
 		Spec: pkgv1.PackageRevisionSpec{DesiredState: pkgv1.PackageRevisionInactive},
 	}
 	ginactive := model.GetConfigurationRevision(&inactive, model.SelectAll)
-	ginactiveSkipUnstructured := model.GetConfigurationRevision(&inactive, model.SkipFields(model.FieldUnstructured))
+	ginactiveSkipUnstructured := model.GetConfigurationRevision(&inactive, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A ConfigurationRevision which we do not control.
 	other := pkgv1.ConfigurationRevision{
@@ -1620,7 +1620,7 @@ func TestQueryConfigurationRevisions(t *testing.T) {
 		},
 	}
 	gother := model.GetConfigurationRevision(&other, model.SelectAll)
-	gotherSkipUnstructured := model.GetConfigurationRevision(&other, model.SkipFields(model.FieldUnstructured))
+	gotherSkipUnstructured := model.GetConfigurationRevision(&other, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
 		&ast.Field{
@@ -1832,7 +1832,7 @@ func TestQueryConfigurationRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1874,11 +1874,11 @@ func TestQueryCompositeResourceDefinitions(t *testing.T) {
 		},
 	}}
 	gowned := model.GetCompositeResourceDefinition(&owned, model.SelectAll)
-	gownedSkipUnstructured := model.GetCompositeResourceDefinition(&owned, model.SkipFields(model.FieldUnstructured))
+	gownedSkipUnstructured := model.GetCompositeResourceDefinition(&owned, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	dangler := extv1.CompositeResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "coolconfig"}}
 	gdangler := model.GetCompositeResourceDefinition(&dangler, model.SelectAll)
-	gdanglerSkipUnstructured := model.GetCompositeResourceDefinition(&dangler, model.SkipFields(model.FieldUnstructured))
+	gdanglerSkipUnstructured := model.GetCompositeResourceDefinition(&dangler, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -2124,7 +2124,7 @@ func TestQueryCompositeResourceDefinitions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrdc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrdc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -2167,11 +2167,11 @@ func TestQueryCompositions(t *testing.T) {
 		},
 	}}
 	gowned := model.GetComposition(&owned, model.SelectAll)
-	gownedSkipUnstructured := model.GetComposition(&owned, model.SkipFields(model.FieldUnstructured))
+	gownedSkipUnstructured := model.GetComposition(&owned, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	dangler := extv1.Composition{ObjectMeta: metav1.ObjectMeta{Name: "coolconfig"}}
 	gdangler := model.GetComposition(&dangler, model.SelectAll)
-	gdanglerSkipUnstructured := model.GetComposition(&dangler, model.SkipFields(model.FieldUnstructured))
+	gdanglerSkipUnstructured := model.GetComposition(&dangler, model.SkipFields(model.FieldUnstructured, model.FieldFieldPath))
 
 	// A selection set with "nodes.unstructured" field included.
 	gselectWithUnstructured := ast.SelectionSet{
@@ -2417,7 +2417,7 @@ func TestQueryCompositions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -1154,12 +1154,12 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 		},
 	})
 
-	gowned := model.GetCustomResourceDefinition(owned)
+	gowned := model.GetCustomResourceDefinition(owned, model.SelectAll)
 
 	dangler := xunstructured.NewCRD()
 	dangler.SetName("coolconfig")
 
-	gdangler := model.GetCustomResourceDefinition(dangler)
+	gdangler := model.GetCustomResourceDefinition(dangler, model.SelectAll)
 
 	type args struct {
 		ctx      context.Context

--- a/internal/graph/resolvers/selection.go
+++ b/internal/graph/resolvers/selection.go
@@ -1,0 +1,74 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolvers
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+// SelectedFields is a set of selected fields.
+type SelectedFields map[string]struct{}
+
+// Has returns true if the field is selected.
+func (s SelectedFields) Has(path string) bool {
+	_, ok := s[path]
+	return ok
+}
+
+func (s SelectedFields) Sub(prefix string) SelectedFields {
+	if len(s) == 0 {
+		return nil
+	}
+	sub := SelectedFields{}
+	for k := range s {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix && k[len(prefix)] == '.' {
+			sub[k[len(prefix)+1:]] = struct{}{}
+		}
+	}
+	return sub
+}
+
+func GetSelectedFields(ctx context.Context) SelectedFields {
+	resctx := graphql.GetFieldContext(ctx)
+	if resctx == nil { // not in a resolver context
+		return nil
+	}
+
+	selection := SelectedFields{}
+	collectSelectedFields(
+		graphql.GetOperationContext(ctx),
+		selection,
+		graphql.CollectFields(graphql.GetOperationContext(ctx), resctx.Field.Selections, nil),
+		"",
+	)
+	return selection
+}
+
+func collectSelectedFields(ctx *graphql.OperationContext, selection SelectedFields, fields []graphql.CollectedField, prefix string) {
+	for _, column := range fields {
+		prefixColumn := fieldPath(prefix, column.Name)
+		selection[prefixColumn] = struct{}{}
+		collectSelectedFields(ctx, selection, graphql.CollectFields(ctx, column.Selections, nil), prefixColumn)
+	}
+}
+
+func fieldPath(prefix, name string) string {
+	if len(prefix) > 0 {
+		return prefix + "." + name
+	}
+	return name
+}

--- a/schema/apiextensions.gql
+++ b/schema/apiextensions.gql
@@ -23,6 +23,91 @@ type CompositeResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -340,6 +425,91 @@ type Composition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/common.gql
+++ b/schema/common.gql
@@ -43,6 +43,91 @@ interface KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection!
@@ -90,6 +175,91 @@ type GenericResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -359,6 +529,91 @@ type Event implements Node {
 
   "An unstructured JSON representation of the event."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 }
 
 """
@@ -421,6 +676,91 @@ type Secret implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   """
   Events pertaining to this resource.
@@ -462,6 +802,91 @@ type ConfigMap implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   # TODO(negz): Support binaryData too? What would the return value be?
 
@@ -526,6 +951,91 @@ type CustomResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/composite.gql
+++ b/schema/composite.gql
@@ -24,6 +24,91 @@ type CompositeResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -126,6 +211,91 @@ type CompositeResourceClaim implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/configuration.gql
+++ b/schema/configuration.gql
@@ -22,6 +22,91 @@ type Configuration implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -140,6 +225,91 @@ type ConfigurationRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/directives.gql
+++ b/schema/directives.gql
@@ -7,6 +7,8 @@ directive @goField(
   forceResolver: Boolean
   name: String
   omittable: Boolean
+  type: String
+  embed: Boolean
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goTag(

--- a/schema/managed.gql
+++ b/schema/managed.gql
@@ -24,6 +24,91 @@ type ManagedResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/provider.gql
+++ b/schema/provider.gql
@@ -22,6 +22,91 @@ type Provider implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -139,6 +224,91 @@ type ProviderRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/providerconfig.gql
+++ b/schema/providerconfig.gql
@@ -20,6 +20,91 @@ type ProviderConfig implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)


### PR DESCRIPTION
This PR buids on #119, as such the diff currently includes both.
To see only new additions, use https://github.com/avalanche123/xgql/compare/no-json-if-not-requested...field-path

- extend gqlgen's goType directive
- add fieldPath and deprecate unstructured

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Add a new field `fieldPath` that deprecates `unstructured` and allows to be
exact in which data needs to be selected:

```gql
{
  name: fieldPath(path: "metadata.name")
  images: fieldPath(path: "spec.containers[*].image")
}
```

Some modification of gqlgen's code generation process was necessary to remove
the no longer used `Unstructured` field and enforce delegation for the "unstructured"
and "fieldPath" fields to the embedded `model.PavedAccess` field of generated
structs.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I've tested it both locally via playground and on a running MCP via console.
