### PR TITLE
fieldPath field and parallel resolving

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/epk/smaz v0.0.0-20220720222521-c11a89997fcf
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-chi/chi/v5 v5.0.3
-	github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929
 	github.com/google/addlicense v0.0.0-20210428195630-6d92264d7170
 	github.com/google/go-cmp v0.5.9
 	github.com/pkg/errors v0.9.1
@@ -91,7 +90,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
-	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.26.1
 	k8s.io/apiextensions-apiserver v0.26.1
-	k8s.io/apimachinery v0.27.1
+	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.26.1
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	sigs.k8s.io/controller-runtime v0.14.5
@@ -109,8 +109,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
-	k8s.io/kube-openapi v0.0.0-20230327201221-f5883ff37f0c // indirect
+	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1256,8 +1256,8 @@ k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655/go.mod h1:nL6pwRT8NgfF8TT
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.19.7/go.mod h1:6sRbGRAVY5DOCuZwB5XkqguBqpqLU6q/kOaOdk29z6Q=
 k8s.io/apimachinery v0.20.1/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
-k8s.io/apimachinery v0.27.1 h1:EGuZiLI95UQQcClhanryclaQE6xjg1Bts6/L3cD7zyc=
-k8s.io/apimachinery v0.27.1/go.mod h1:5ikh59fK3AJ287GUvpUsryoMFtH9zj/ARfWCo3AyXTM=
+k8s.io/apimachinery v0.27.3 h1:Ubye8oBufD04l9QnNtW05idcOe9Z3GQN8+7PqmuVcUM=
+k8s.io/apimachinery v0.27.3/go.mod h1:XNfZ6xklnMCOGGFNqXG7bUrQCoR04dh/E7FprV6pb+E=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.18.2/go.mod h1:Xbh066NqrZO8cbsoenCwyDJ1OSi8Ag8I2lezeHxzwzw=
 k8s.io/apiserver v0.19.7/go.mod h1:DmWVQggNePspa+vSsVytVbS3iBSDTXdJVt0akfHacKk=
@@ -1301,8 +1301,8 @@ k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C
 k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kube-openapi v0.0.0-20210113233702-8566a335510f/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
-k8s.io/kube-openapi v0.0.0-20230327201221-f5883ff37f0c h1:EFfsozyzZ/pggw5qNx7ftTVZdp7WZl+3ih89GEjYEK8=
-k8s.io/kube-openapi v0.0.0-20230327201221-f5883ff37f0c/go.mod h1:byini6yhqGC14c3ebc/QwanvYwhuMWF6yz2F8uwW8eg=
+k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f h1:2kWPakN3i/k81b0gvD5C5FJ2kxm1WrQFanWchyKuqGg=
+k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f/go.mod h1:byini6yhqGC14c3ebc/QwanvYwhuMWF6yz2F8uwW8eg=
 k8s.io/legacy-cloud-providers v0.19.7/go.mod h1:dsZk4gH9QIwAtHQ8CK0Ps257xlfgoXE3tMkMNhW2xDU=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
@@ -1334,8 +1334,8 @@ sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
+sigs.k8s.io/structured-merge-diff/v4 v4.3.0 h1:UZbZAZfX0wV2zr7YZorDz6GXROfDFj6LvqCRm4VUVKk=
+sigs.k8s.io/structured-merge-diff/v4 v4.3.0/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,6 @@ github.com/go-chi/chi/v5 v5.0.3/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITL
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929 h1:GdbUZo0+623j+pKRhwwdf1q28IUgRc7asx3TjF9b7VQ=
-github.com/go-json-experiment/json v0.0.0-20230321051131-ccbac49a6929/go.mod h1:AHV+bpNGVGD0DCHMBhhTYtT7yeBYD9Yk92XAjB7vOgo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -812,8 +810,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -19,7 +19,7 @@
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
 // Generate xgql models, bindings, etc per gqlgen.yaml.
-//go:generate go run -tags generate github.com/99designs/gqlgen
+//go:generate go run -tags generate ./graph/generate/gqlgen
 
 // Add license headers to all files.
 //go:generate go run -tags generate github.com/google/addlicense -v -c "Upbound Inc" . ../cmd

--- a/internal/graph/generate/gqlgen/main.go
+++ b/internal/graph/generate/gqlgen/main.go
@@ -62,7 +62,8 @@ func importType(typeRef string) types.Type {
 }
 
 // goTypeFieldHook is a mutation function for modelgen plugin.
-// It extends gqlgens `goField` directive to allow overriding field type make the field embedded.
+// It extends gqlgens `goField` directive, allowing to override
+// field type or make the field embedded.
 //
 // For a brief explanation of Field Mutate Hooks read [GQLGen Recipes].
 //
@@ -76,9 +77,11 @@ func goTypeFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *modelgen.Fi
 
 	c := fd.Directives.ForName("goField")
 	if c != nil {
+		// override field type with "type".
 		if typeRef := c.Arguments.ForName("type"); typeRef != nil {
 			f.Type = importType(typeRef.Value.Raw)
 		}
+		// reset field name if marked with "embed".
 		if embed := c.Arguments.ForName("embed"); embed != nil {
 			if do, err := embed.Value.Value(nil); err == nil && do.(bool) {
 				f.GoName = ""

--- a/internal/graph/generate/gqlgen/main.go
+++ b/internal/graph/generate/gqlgen/main.go
@@ -1,0 +1,112 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build generate
+// +build generate
+
+package main
+
+import (
+	"fmt"
+	"go/types"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/99designs/gqlgen/api"
+	"github.com/99designs/gqlgen/codegen/config"
+	"github.com/99designs/gqlgen/plugin/modelgen"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// importType imports a type from a string reference.
+func importType(typeRef string) types.Type {
+	if typeRef[0] == '*' {
+		return types.NewPointer(importType(typeRef[1:]))
+	}
+	if strings.HasPrefix(typeRef, "[]") {
+		return types.NewSlice(importType(typeRef[2:]))
+	}
+
+	typeSep := strings.LastIndex(typeRef, ".")
+	if typeSep == -1 { // builtinType
+		return types.Universe.Lookup(typeRef).Type()
+	}
+
+	// typeName is <pkg>.<typeName>
+	pkgPath := typeRef[:typeSep]
+	typeRef = typeRef[typeSep+1:]
+
+	// pkgPath is <pkgPath...>/<pkgName>
+	pkgName := pkgPath
+	if pathSep := strings.LastIndex(pkgPath, "/"); pathSep != -1 {
+		pkgName = pkgPath[pathSep+1:]
+	}
+
+	pkg := types.NewPackage(pkgPath, pkgName)
+	// gqlgen doesn't use some of the fields, so we leave them 0/nil
+	return types.NewNamed(types.NewTypeName(0, pkg, typeRef, nil), nil, nil)
+
+}
+
+// goTypeFieldHook is a mutation function for modelgen plugin.
+// It extends gqlgens `goField` directive to allow overriding field type make the field embedded.
+//
+// For a brief explanation of Field Mutate Hooks read [GQLGen Recipes].
+//
+// [GQLGen Recipes]: https://gqlgen.com/recipes/modelgen-hook/#fieldmutatehook
+func goTypeFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *modelgen.Field) (*modelgen.Field, error) {
+	// Call default hook to proceed standard directives like goField and goTag.
+	// You can omit it, if you don't need.
+	if f, err := modelgen.DefaultFieldMutateHook(td, fd, f); err != nil {
+		return f, err
+	}
+
+	c := fd.Directives.ForName("goField")
+	if c != nil {
+		if typeRef := c.Arguments.ForName("type"); typeRef != nil {
+			f.Type = importType(typeRef.Value.Raw)
+		}
+		if embed := c.Arguments.ForName("embed"); embed != nil {
+			if do, err := embed.Value.Value(nil); err == nil && do.(bool) {
+				f.GoName = ""
+			}
+		}
+	}
+
+	return f, nil
+}
+
+func main() {
+	// Disable log output from gqlgen.
+	log.SetOutput(io.Discard)
+	cfg, err := config.LoadConfigFromDefaultLocations()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to load config", err.Error())
+		os.Exit(2)
+	}
+
+	// Attaching the mutation function onto modelgen plugin
+	p := modelgen.Plugin{
+		FieldHook: goTypeFieldHook,
+	}
+
+	err = api.Generate(cfg, api.ReplacePlugin(&p))
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(3)
+	}
+}

--- a/internal/graph/generated/generated.go
+++ b/internal/graph/generated/generated.go
@@ -71,6 +71,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -83,6 +84,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -131,6 +133,7 @@ type ComplexityRoot struct {
 		DefinedCompositeResourceClaims func(childComplexity int, version *string, namespace *string, options *model.DefinedCompositeResourceClaimOptionsInput) int
 		DefinedCompositeResources      func(childComplexity int, version *string, options *model.DefinedCompositeResourceOptionsInput) int
 		Events                         func(childComplexity int) int
+		FieldPath                      func(childComplexity int, path *string) int
 		ID                             func(childComplexity int) int
 		Kind                           func(childComplexity int) int
 		Metadata                       func(childComplexity int) int
@@ -203,6 +206,7 @@ type ComplexityRoot struct {
 	Composition struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -237,6 +241,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Data         func(childComplexity int, keys []string) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -247,6 +252,7 @@ type ComplexityRoot struct {
 		APIVersion     func(childComplexity int) int
 		ActiveRevision func(childComplexity int) int
 		Events         func(childComplexity int) int
+		FieldPath      func(childComplexity int, path *string) int
 		ID             func(childComplexity int) int
 		Kind           func(childComplexity int) int
 		Metadata       func(childComplexity int) int
@@ -264,6 +270,7 @@ type ComplexityRoot struct {
 	ConfigurationRevision struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -328,6 +335,7 @@ type ComplexityRoot struct {
 		APIVersion       func(childComplexity int) int
 		DefinedResources func(childComplexity int, version *string) int
 		Events           func(childComplexity int) int
+		FieldPath        func(childComplexity int, path *string) int
 		ID               func(childComplexity int) int
 		Kind             func(childComplexity int) int
 		Metadata         func(childComplexity int) int
@@ -378,6 +386,7 @@ type ComplexityRoot struct {
 	Event struct {
 		APIVersion     func(childComplexity int) int
 		Count          func(childComplexity int) int
+		FieldPath      func(childComplexity int, path *string) int
 		FirstTime      func(childComplexity int) int
 		ID             func(childComplexity int) int
 		InvolvedObject func(childComplexity int) int
@@ -403,6 +412,7 @@ type ComplexityRoot struct {
 	GenericResource struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -426,6 +436,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -493,6 +504,7 @@ type ComplexityRoot struct {
 		APIVersion     func(childComplexity int) int
 		ActiveRevision func(childComplexity int) int
 		Events         func(childComplexity int) int
+		FieldPath      func(childComplexity int, path *string) int
 		ID             func(childComplexity int) int
 		Kind           func(childComplexity int) int
 		Metadata       func(childComplexity int) int
@@ -506,6 +518,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Definition   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -530,6 +543,7 @@ type ComplexityRoot struct {
 	ProviderRevision struct {
 		APIVersion   func(childComplexity int) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -596,6 +610,7 @@ type ComplexityRoot struct {
 		APIVersion   func(childComplexity int) int
 		Data         func(childComplexity int, keys []string) int
 		Events       func(childComplexity int) int
+		FieldPath    func(childComplexity int, path *string) int
 		ID           func(childComplexity int) int
 		Kind         func(childComplexity int) int
 		Metadata     func(childComplexity int) int
@@ -769,6 +784,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CompositeResource.Events(childComplexity), true
 
+	case "CompositeResource.fieldPath":
+		if e.complexity.CompositeResource.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CompositeResource_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CompositeResource.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "CompositeResource.id":
 		if e.complexity.CompositeResource.ID == nil {
 			break
@@ -831,6 +858,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CompositeResourceClaim.Events(childComplexity), true
+
+	case "CompositeResourceClaim.fieldPath":
+		if e.complexity.CompositeResourceClaim.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CompositeResourceClaim_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CompositeResourceClaim.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "CompositeResourceClaim.id":
 		if e.complexity.CompositeResourceClaim.ID == nil {
@@ -1030,6 +1069,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CompositeResourceDefinition.Events(childComplexity), true
+
+	case "CompositeResourceDefinition.fieldPath":
+		if e.complexity.CompositeResourceDefinition.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CompositeResourceDefinition_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CompositeResourceDefinition.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "CompositeResourceDefinition.id":
 		if e.complexity.CompositeResourceDefinition.ID == nil {
@@ -1325,6 +1376,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Composition.Events(childComplexity), true
 
+	case "Composition.fieldPath":
+		if e.complexity.Composition.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Composition_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Composition.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Composition.id":
 		if e.complexity.Composition.ID == nil {
 			break
@@ -1463,6 +1526,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ConfigMap.Events(childComplexity), true
 
+	case "ConfigMap.fieldPath":
+		if e.complexity.ConfigMap.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ConfigMap_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ConfigMap.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "ConfigMap.id":
 		if e.complexity.ConfigMap.ID == nil {
 			break
@@ -1511,6 +1586,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Configuration.Events(childComplexity), true
+
+	case "Configuration.fieldPath":
+		if e.complexity.Configuration.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Configuration_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Configuration.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "Configuration.id":
 		if e.complexity.Configuration.ID == nil {
@@ -1588,6 +1675,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ConfigurationRevision.Events(childComplexity), true
+
+	case "ConfigurationRevision.fieldPath":
+		if e.complexity.ConfigurationRevision.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ConfigurationRevision_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ConfigurationRevision.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ConfigurationRevision.id":
 		if e.complexity.ConfigurationRevision.ID == nil {
@@ -1853,6 +1952,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CustomResourceDefinition.Events(childComplexity), true
 
+	case "CustomResourceDefinition.fieldPath":
+		if e.complexity.CustomResourceDefinition.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_CustomResourceDefinition_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.CustomResourceDefinition.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "CustomResourceDefinition.id":
 		if e.complexity.CustomResourceDefinition.ID == nil {
 			break
@@ -2035,6 +2146,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Event.Count(childComplexity), true
 
+	case "Event.fieldPath":
+		if e.complexity.Event.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Event_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Event.firstTime":
 		if e.complexity.Event.FirstTime == nil {
 			break
@@ -2147,6 +2270,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.GenericResource.Events(childComplexity), true
 
+	case "GenericResource.fieldPath":
+		if e.complexity.GenericResource.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_GenericResource_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.GenericResource.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "GenericResource.id":
 		if e.complexity.GenericResource.ID == nil {
 			break
@@ -2223,6 +2358,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ManagedResource.Events(childComplexity), true
+
+	case "ManagedResource.fieldPath":
+		if e.complexity.ManagedResource.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ManagedResource_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ManagedResource.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ManagedResource.id":
 		if e.complexity.ManagedResource.ID == nil {
@@ -2529,6 +2676,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Provider.Events(childComplexity), true
 
+	case "Provider.fieldPath":
+		if e.complexity.Provider.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Provider_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Provider.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Provider.id":
 		if e.complexity.Provider.ID == nil {
 			break
@@ -2598,6 +2757,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProviderConfig.Events(childComplexity), true
+
+	case "ProviderConfig.fieldPath":
+		if e.complexity.ProviderConfig.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ProviderConfig_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ProviderConfig.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ProviderConfig.id":
 		if e.complexity.ProviderConfig.ID == nil {
@@ -2682,6 +2853,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProviderRevision.Events(childComplexity), true
+
+	case "ProviderRevision.fieldPath":
+		if e.complexity.ProviderRevision.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_ProviderRevision_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ProviderRevision.FieldPath(childComplexity, args["path"].(*string)), true
 
 	case "ProviderRevision.id":
 		if e.complexity.ProviderRevision.ID == nil {
@@ -3058,6 +3241,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Secret.Events(childComplexity), true
 
+	case "Secret.fieldPath":
+		if e.complexity.Secret.FieldPath == nil {
+			break
+		}
+
+		args, err := ec.field_Secret_fieldPath_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Secret.FieldPath(childComplexity, args["path"].(*string)), true
+
 	case "Secret.id":
 		if e.complexity.Secret.ID == nil {
 			break
@@ -3263,6 +3458,91 @@ type CompositeResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -3580,6 +3860,91 @@ type Composition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -3658,6 +4023,91 @@ interface KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection!
@@ -3705,6 +4155,91 @@ type GenericResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -3974,6 +4509,91 @@ type Event implements Node {
 
   "An unstructured JSON representation of the event."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 }
 
 """
@@ -4036,6 +4656,91 @@ type Secret implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   """
   Events pertaining to this resource.
@@ -4077,6 +4782,91 @@ type ConfigMap implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   # TODO(negz): Support binaryData too? What would the return value be?
 
@@ -4141,6 +4931,91 @@ type CustomResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4313,6 +5188,91 @@ type CompositeResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4415,6 +5375,91 @@ type CompositeResourceClaim implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4511,6 +5556,91 @@ type Configuration implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4629,6 +5759,91 @@ type ConfigurationRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -4726,6 +5941,8 @@ directive @goField(
   forceResolver: Boolean
   name: String
   omittable: Boolean
+  type: String
+  embed: Boolean
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goTag(
@@ -4759,6 +5976,91 @@ type ManagedResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5017,6 +6319,91 @@ type Provider implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5134,6 +6521,91 @@ type ProviderRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5243,6 +6715,91 @@ type ProviderConfig implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use ` + "`" + `fieldPath` + "`" + ` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as ` + "`" + `metadata.name` + "`" + `.
+
+  Valid examples:
+
+  * ` + "`" + `metadata.name` + "`" + `
+  * ` + "`" + `spec.containers[0].name` + "`" + `
+  * ` + "`" + `data[.config.yml]` + "`" + `
+  * ` + "`" + `metadata.annotations['crossplane.io/external-name']` + "`" + `
+  * ` + "`" + `spec.items[0][8]` + "`" + `
+  * ` + "`" + `apiVersion` + "`" + `
+  * ` + "`" + `[42]` + "`" + `
+  * ` + "`" + `spec.containers[*].args[*]` + "`" + ` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * ` + "`" + `.metadata.name` + "`" + ` - Leading period.
+  * ` + "`" + `metadata..name` + "`" + ` - Double period.
+  * ` + "`" + `metadata.name.` + "`" + ` - Trailing period.
+  * ` + "`" + `spec.containers[]` + "`" + ` - Empty brackets.
+  * ` + "`" + `spec.containers.[0].name` + "`" + ` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  The wildcard ` + "`" + `spec.containers[*].args[*]` + "`" + ` will be expanded to:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  And the following result will be returned:
+
+  ` + "`" + `` + "`" + `` + "`" + `json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ` + "`" + `` + "`" + `` + "`" + `
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -5530,6 +7087,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 
 // region    ***************************** args.gotpl *****************************
 
+func (ec *executionContext) field_CompositeResourceClaim_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_CompositeResourceDefinition_definedCompositeResourceClaims_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -5587,6 +7159,51 @@ func (ec *executionContext) field_CompositeResourceDefinition_definedCompositeRe
 	return args, nil
 }
 
+func (ec *executionContext) field_CompositeResourceDefinition_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_CompositeResource_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Composition_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_ConfigMap_data_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -5602,6 +7219,51 @@ func (ec *executionContext) field_ConfigMap_data_args(ctx context.Context, rawAr
 	return args, nil
 }
 
+func (ec *executionContext) field_ConfigMap_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ConfigurationRevision_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Configuration_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_CustomResourceDefinition_definedResources_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -5614,6 +7276,66 @@ func (ec *executionContext) field_CustomResourceDefinition_definedResources_args
 		}
 	}
 	args["version"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_CustomResourceDefinition_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Event_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_GenericResource_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ManagedResource_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
 	return args, nil
 }
 
@@ -5698,6 +7420,51 @@ func (ec *executionContext) field_ObjectMeta_labels_args(ctx context.Context, ra
 		}
 	}
 	args["keys"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ProviderConfig_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_ProviderRevision_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Provider_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
 	return args, nil
 }
 
@@ -5974,6 +7741,21 @@ func (ec *executionContext) field_Secret_data_args(ctx context.Context, rawArgs 
 		}
 	}
 	args["keys"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Secret_fieldPath_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["path"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("path"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["path"] = arg0
 	return args, nil
 }
 
@@ -6340,7 +8122,7 @@ func (ec *executionContext) _CompositeResource_unstructured(ctx context.Context,
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6361,11 +8143,66 @@ func (ec *executionContext) fieldContext_CompositeResource_unstructured(ctx cont
 	fc = &graphql.FieldContext{
 		Object:     "CompositeResource",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompositeResource_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompositeResource_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompositeResource_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompositeResource",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CompositeResource_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -6470,6 +8307,8 @@ func (ec *executionContext) fieldContext_CompositeResource_definition(ctx contex
 				return ec.fieldContext_CompositeResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceDefinition_events(ctx, field)
 			case "compositeResourceCRD":
@@ -6810,7 +8649,7 @@ func (ec *executionContext) _CompositeResourceClaim_unstructured(ctx context.Con
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6831,11 +8670,66 @@ func (ec *executionContext) fieldContext_CompositeResourceClaim_unstructured(ctx
 	fc = &graphql.FieldContext{
 		Object:     "CompositeResourceClaim",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompositeResourceClaim_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceClaim) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompositeResourceClaim_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompositeResourceClaim_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompositeResourceClaim",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CompositeResourceClaim_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -6940,6 +8834,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaim_definition(ctx c
 				return ec.fieldContext_CompositeResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceDefinition_events(ctx, field)
 			case "compositeResourceCRD":
@@ -7007,6 +8903,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimConnection_nodes(
 				return ec.fieldContext_CompositeResourceClaim_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceClaim_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceClaim_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceClaim_events(ctx, field)
 			case "definition":
@@ -7153,6 +9051,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimSpec_composition(
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -7302,6 +9202,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimSpec_resource(ctx
 				return ec.fieldContext_CompositeResource_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResource_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResource_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResource_events(ctx, field)
 			case "definition":
@@ -7412,6 +9314,8 @@ func (ec *executionContext) fieldContext_CompositeResourceClaimSpec_connectionSe
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -7616,6 +9520,8 @@ func (ec *executionContext) fieldContext_CompositeResourceConnection_nodes(ctx c
 				return ec.fieldContext_CompositeResource_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResource_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResource_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResource_events(ctx, field)
 			case "definition":
@@ -8035,7 +9941,7 @@ func (ec *executionContext) _CompositeResourceDefinition_unstructured(ctx contex
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8056,11 +9962,66 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinition_unstructure
 	fc = &graphql.FieldContext{
 		Object:     "CompositeResourceDefinition",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompositeResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CompositeResourceDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompositeResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompositeResourceDefinition",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CompositeResourceDefinition_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -8165,6 +10126,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinition_compositeRe
 				return ec.fieldContext_CustomResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CustomResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CustomResourceDefinition_events(ctx, field)
 			case "definedResources":
@@ -8226,6 +10189,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinition_compositeRe
 				return ec.fieldContext_CustomResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CustomResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CustomResourceDefinition_events(ctx, field)
 			case "definedResources":
@@ -8409,6 +10374,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinitionConnection_n
 				return ec.fieldContext_CompositeResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceDefinition_events(ctx, field)
 			case "compositeResourceCRD":
@@ -9064,6 +11031,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinitionSpec_default
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -9123,6 +11092,8 @@ func (ec *executionContext) fieldContext_CompositeResourceDefinitionSpec_enforce
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -9510,6 +11481,8 @@ func (ec *executionContext) fieldContext_CompositeResourceSpec_composition(ctx c
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -9659,6 +11632,8 @@ func (ec *executionContext) fieldContext_CompositeResourceSpec_claim(ctx context
 				return ec.fieldContext_CompositeResourceClaim_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CompositeResourceClaim_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CompositeResourceClaim_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CompositeResourceClaim_events(ctx, field)
 			case "definition":
@@ -9769,6 +11744,8 @@ func (ec *executionContext) fieldContext_CompositeResourceSpec_connectionSecret(
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -10325,7 +12302,7 @@ func (ec *executionContext) _Composition_unstructured(ctx context.Context, field
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10346,11 +12323,66 @@ func (ec *executionContext) fieldContext_Composition_unstructured(ctx context.Co
 	fc = &graphql.FieldContext{
 		Object:     "Composition",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Composition_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Composition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Composition_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Composition_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Composition",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Composition_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -10455,6 +12487,8 @@ func (ec *executionContext) fieldContext_CompositionConnection_nodes(ctx context
 				return ec.fieldContext_Composition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Composition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Composition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Composition_events(ctx, field)
 			}
@@ -11137,7 +13171,7 @@ func (ec *executionContext) _ConfigMap_unstructured(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -11158,11 +13192,66 @@ func (ec *executionContext) fieldContext_ConfigMap_unstructured(ctx context.Cont
 	fc = &graphql.FieldContext{
 		Object:     "ConfigMap",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConfigMap_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ConfigMap) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConfigMap_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConfigMap_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConfigMap",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ConfigMap_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -11540,7 +13629,7 @@ func (ec *executionContext) _Configuration_unstructured(ctx context.Context, fie
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -11561,11 +13650,66 @@ func (ec *executionContext) fieldContext_Configuration_unstructured(ctx context.
 	fc = &graphql.FieldContext{
 		Object:     "Configuration",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Configuration_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Configuration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Configuration_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Configuration_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Configuration",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Configuration_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -11720,6 +13864,8 @@ func (ec *executionContext) fieldContext_Configuration_activeRevision(ctx contex
 				return ec.fieldContext_ConfigurationRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ConfigurationRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ConfigurationRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ConfigurationRevision_events(ctx, field)
 			}
@@ -11779,6 +13925,8 @@ func (ec *executionContext) fieldContext_ConfigurationConnection_nodes(ctx conte
 				return ec.fieldContext_Configuration_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Configuration_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Configuration_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Configuration_events(ctx, field)
 			case "revisions":
@@ -12165,7 +14313,7 @@ func (ec *executionContext) _ConfigurationRevision_unstructured(ctx context.Cont
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -12186,11 +14334,66 @@ func (ec *executionContext) fieldContext_ConfigurationRevision_unstructured(ctx 
 	fc = &graphql.FieldContext{
 		Object:     "ConfigurationRevision",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConfigurationRevision_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ConfigurationRevision) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConfigurationRevision_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConfigurationRevision_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConfigurationRevision",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ConfigurationRevision_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -12295,6 +14498,8 @@ func (ec *executionContext) fieldContext_ConfigurationRevisionConnection_nodes(c
 				return ec.fieldContext_ConfigurationRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ConfigurationRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ConfigurationRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ConfigurationRevision_events(ctx, field)
 			}
@@ -13798,7 +16003,7 @@ func (ec *executionContext) _CustomResourceDefinition_unstructured(ctx context.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -13819,11 +16024,66 @@ func (ec *executionContext) fieldContext_CustomResourceDefinition_unstructured(c
 	fc = &graphql.FieldContext{
 		Object:     "CustomResourceDefinition",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CustomResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.CustomResourceDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CustomResourceDefinition_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CustomResourceDefinition",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_CustomResourceDefinition_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -13989,6 +16249,8 @@ func (ec *executionContext) fieldContext_CustomResourceDefinitionConnection_node
 				return ec.fieldContext_CustomResourceDefinition_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_CustomResourceDefinition_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_CustomResourceDefinition_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_CustomResourceDefinition_events(ctx, field)
 			case "definedResources":
@@ -15310,7 +17572,7 @@ func (ec *executionContext) _Event_unstructured(ctx context.Context, field graph
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15331,11 +17593,66 @@ func (ec *executionContext) fieldContext_Event_unstructured(ctx context.Context,
 	fc = &graphql.FieldContext{
 		Object:     "Event",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Event_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Event) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Event_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Event_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Event",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Event_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -15402,6 +17719,8 @@ func (ec *executionContext) fieldContext_EventConnection_nodes(ctx context.Conte
 				return ec.fieldContext_Event_lastTime(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Event_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Event_fieldPath(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Event", field.Name)
 		},
@@ -15710,7 +18029,7 @@ func (ec *executionContext) _GenericResource_unstructured(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15731,11 +18050,66 @@ func (ec *executionContext) fieldContext_GenericResource_unstructured(ctx contex
 	fc = &graphql.FieldContext{
 		Object:     "GenericResource",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GenericResource_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.GenericResource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GenericResource_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GenericResource_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GenericResource",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_GenericResource_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -16273,7 +18647,7 @@ func (ec *executionContext) _ManagedResource_unstructured(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -16294,11 +18668,66 @@ func (ec *executionContext) fieldContext_ManagedResource_unstructured(ctx contex
 	fc = &graphql.FieldContext{
 		Object:     "ManagedResource",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ManagedResource_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ManagedResource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ManagedResource_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ManagedResource_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ManagedResource",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ManagedResource_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -16444,6 +18873,8 @@ func (ec *executionContext) fieldContext_ManagedResourceSpec_connectionSecret(ct
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -18137,7 +20568,7 @@ func (ec *executionContext) _Provider_unstructured(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -18158,11 +20589,66 @@ func (ec *executionContext) fieldContext_Provider_unstructured(ctx context.Conte
 	fc = &graphql.FieldContext{
 		Object:     "Provider",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Provider_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Provider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Provider_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Provider_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Provider",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Provider_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -18317,6 +20803,8 @@ func (ec *executionContext) fieldContext_Provider_activeRevision(ctx context.Con
 				return ec.fieldContext_ProviderRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ProviderRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ProviderRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ProviderRevision_events(ctx, field)
 			}
@@ -18589,7 +21077,7 @@ func (ec *executionContext) _ProviderConfig_unstructured(ctx context.Context, fi
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -18610,11 +21098,66 @@ func (ec *executionContext) fieldContext_ProviderConfig_unstructured(ctx context
 	fc = &graphql.FieldContext{
 		Object:     "ProviderConfig",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProviderConfig_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ProviderConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProviderConfig_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProviderConfig_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProviderConfig",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ProviderConfig_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -18898,6 +21441,8 @@ func (ec *executionContext) fieldContext_ProviderConnection_nodes(ctx context.Co
 				return ec.fieldContext_Provider_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Provider_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Provider_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Provider_events(ctx, field)
 			case "revisions":
@@ -19284,7 +21829,7 @@ func (ec *executionContext) _ProviderRevision_unstructured(ctx context.Context, 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -19305,11 +21850,66 @@ func (ec *executionContext) fieldContext_ProviderRevision_unstructured(ctx conte
 	fc = &graphql.FieldContext{
 		Object:     "ProviderRevision",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProviderRevision_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.ProviderRevision) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProviderRevision_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProviderRevision_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProviderRevision",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ProviderRevision_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -19414,6 +22014,8 @@ func (ec *executionContext) fieldContext_ProviderRevisionConnection_nodes(ctx co
 				return ec.fieldContext_ProviderRevision_status(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ProviderRevision_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ProviderRevision_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ProviderRevision_events(ctx, field)
 			}
@@ -20609,6 +23211,8 @@ func (ec *executionContext) fieldContext_Query_secret(ctx context.Context, field
 				return ec.fieldContext_Secret_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_Secret_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_Secret_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_Secret_events(ctx, field)
 			}
@@ -20677,6 +23281,8 @@ func (ec *executionContext) fieldContext_Query_configMap(ctx context.Context, fi
 				return ec.fieldContext_ConfigMap_data(ctx, field)
 			case "unstructured":
 				return ec.fieldContext_ConfigMap_unstructured(ctx, field)
+			case "fieldPath":
+				return ec.fieldContext_ConfigMap_fieldPath(ctx, field)
 			case "events":
 				return ec.fieldContext_ConfigMap_events(ctx, field)
 			}
@@ -21601,7 +24207,7 @@ func (ec *executionContext) _Secret_unstructured(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Unstructured, nil
+		return obj.Unstructured(), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -21622,11 +24228,66 @@ func (ec *executionContext) fieldContext_Secret_unstructured(ctx context.Context
 	fc = &graphql.FieldContext{
 		Object:     "Secret",
 		Field:      field,
-		IsMethod:   false,
+		IsMethod:   true,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type JSON does not have child fields")
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Secret_fieldPath(ctx context.Context, field graphql.CollectedField, obj *model.Secret) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Secret_fieldPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FieldPath(fc.Args["path"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]byte)
+	fc.Result = res
+	return ec.marshalNJSON2ᚕbyte(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Secret_fieldPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Secret",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Secret_fieldPath_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -24260,6 +26921,11 @@ func (ec *executionContext) _CompositeResource(ctx context.Context, sel ast.Sele
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._CompositeResource_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -24392,6 +27058,11 @@ func (ec *executionContext) _CompositeResourceClaim(ctx context.Context, sel ast
 			out.Values[i] = ec._CompositeResourceClaim_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._CompositeResourceClaim_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._CompositeResourceClaim_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -24953,6 +27624,11 @@ func (ec *executionContext) _CompositeResourceDefinition(ctx context.Context, se
 			out.Values[i] = ec._CompositeResourceDefinition_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._CompositeResourceDefinition_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._CompositeResourceDefinition_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -25876,6 +28552,11 @@ func (ec *executionContext) _Composition(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._Composition_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -26147,6 +28828,11 @@ func (ec *executionContext) _ConfigMap(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._ConfigMap_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -26246,6 +28932,11 @@ func (ec *executionContext) _Configuration(ctx context.Context, sel ast.Selectio
 			out.Values[i] = ec._Configuration_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._Configuration_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._Configuration_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -26458,6 +29149,11 @@ func (ec *executionContext) _ConfigurationRevision(ctx context.Context, sel ast.
 			out.Values[i] = ec._ConfigurationRevision_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ConfigurationRevision_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ConfigurationRevision_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -26946,6 +29642,11 @@ func (ec *executionContext) _CustomResourceDefinition(ctx context.Context, sel a
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._CustomResourceDefinition_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -27425,6 +30126,11 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._Event_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -27558,6 +30264,11 @@ func (ec *executionContext) _GenericResource(ctx context.Context, sel ast.Select
 			}
 		case "unstructured":
 			out.Values[i] = ec._GenericResource_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._GenericResource_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -27776,6 +30487,11 @@ func (ec *executionContext) _ManagedResource(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._ManagedResource_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ManagedResource_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ManagedResource_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -28391,6 +31107,11 @@ func (ec *executionContext) _Provider(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "fieldPath":
+			out.Values[i] = ec._Provider_fieldPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "events":
 			field := field
 
@@ -28554,6 +31275,11 @@ func (ec *executionContext) _ProviderConfig(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._ProviderConfig_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ProviderConfig_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ProviderConfig_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -28807,6 +31533,11 @@ func (ec *executionContext) _ProviderRevision(ctx context.Context, sel ast.Selec
 			out.Values[i] = ec._ProviderRevision_status(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._ProviderRevision_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._ProviderRevision_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -29498,6 +32229,11 @@ func (ec *executionContext) _Secret(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec._Secret_data(ctx, field, obj)
 		case "unstructured":
 			out.Values[i] = ec._Secret_unstructured(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fieldPath":
+			out.Values[i] = ec._Secret_fieldPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/internal/graph/model/apiextensions.go
+++ b/internal/graph/model/apiextensions.go
@@ -138,8 +138,10 @@ func GetCompositeResourceDefinition(xrd *extv1.CompositeResourceDefinition) Comp
 			DefaultCompositionReference:  xrd.Spec.DefaultCompositionRef,
 			EnforcedCompositionReference: xrd.Spec.EnforcedCompositionRef,
 		},
-		Status:       GetCompositeResourceDefinitionStatus(xrd.Status),
-		Unstructured: unstruct(xrd),
+		Status: GetCompositeResourceDefinitionStatus(xrd.Status),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(xrd),
+		},
 	}
 }
 
@@ -169,8 +171,10 @@ func GetComposition(cmp *extv1.Composition) Composition {
 			},
 			WriteConnectionSecretsToNamespace: cmp.Spec.WriteConnectionSecretsToNamespace,
 		},
-		Status:       GetCompositionStatus(cmp.Status),
-		Unstructured: unstruct(cmp),
+		Status: GetCompositionStatus(cmp.Status),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(cmp),
+		},
 	}
 }
 

--- a/internal/graph/model/apiextensions_test.go
+++ b/internal/graph/model/apiextensions_test.go
@@ -163,7 +163,7 @@ func TestGetCompositeResourceDefinition(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetCompositeResourceDefinition(tc.xrd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CompositeResourceDefinition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CompositeResourceDefinition{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCompositeResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -242,7 +242,7 @@ func TestGetComposition(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetComposition(tc.xrd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Composition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Composition{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetComposition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	extv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 
@@ -117,10 +118,12 @@ func GetGenericResource(u *kunstructured.Unstructured) GenericResource {
 			Namespace:  u.GetNamespace(),
 			Name:       u.GetName(),
 		},
-		APIVersion:   u.GetAPIVersion(),
-		Kind:         u.GetKind(),
-		Metadata:     GetObjectMeta(u),
-		Unstructured: bytesForUnstructured(u),
+		APIVersion: u.GetAPIVersion(),
+		Kind:       u.GetKind(),
+		Metadata:   GetObjectMeta(u),
+		PavedAccess: PavedAccess{
+			Paved: fieldpath.Pave(u.Object),
+		},
 	}
 }
 
@@ -161,10 +164,12 @@ func GetSecret(s *corev1.Secret) Secret {
 			Namespace:  s.GetNamespace(),
 			Name:       s.GetName(),
 		},
-		APIVersion:   corev1.SchemeGroupVersion.String(),
-		Kind:         "Secret",
-		Metadata:     GetObjectMeta(s),
-		Unstructured: unstruct(s),
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "Secret",
+		Metadata:   GetObjectMeta(s),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(s),
+		},
 	}
 
 	if s.Data != nil {
@@ -190,11 +195,13 @@ func GetConfigMap(cm *corev1.ConfigMap) ConfigMap {
 			Namespace:  cm.GetNamespace(),
 			Name:       cm.GetName(),
 		},
-		APIVersion:   corev1.SchemeGroupVersion.String(),
-		Kind:         "ConfigMap",
-		Metadata:     GetObjectMeta(cm),
-		Unstructured: unstruct(cm),
-		data:         cm.Data,
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "ConfigMap",
+		Metadata:   GetObjectMeta(cm),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(cm),
+		},
+		data: cm.Data,
 	}
 }
 
@@ -301,8 +308,10 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition) Cus
 			Scope:    GetResourceScope(crd.GetSpecScope()),
 			Versions: GetCustomResourceDefinitionVersions(crd.GetSpecVersions()),
 		},
-		Status:       GetCustomResourceDefinitionStatus(crd.GetStatus()),
-		Unstructured: bytesForUnstructured(&crd.Unstructured),
+		Status: GetCustomResourceDefinitionStatus(crd.GetStatus()),
+		PavedAccess: PavedAccess{
+			Paved: fieldpath.Pave(crd.Object),
+		},
 	}
 }
 

--- a/internal/graph/model/common.go
+++ b/internal/graph/model/common.go
@@ -306,29 +306,6 @@ func GetCustomResourceDefinition(crd *unstructured.CustomResourceDefinition) Cus
 	}
 }
 
-// GetCustomResourceDefinitionFromCRD from the suppled Kubernetes CRD.
-func GetCustomResourceDefinitionFromCRD(crd *kextv1.CustomResourceDefinition) CustomResourceDefinition {
-	return CustomResourceDefinition{
-		ID: ReferenceID{
-			APIVersion: crd.APIVersion,
-			Kind:       crd.Kind,
-			Name:       crd.GetName(),
-		},
-
-		APIVersion: crd.APIVersion,
-		Kind:       crd.Kind,
-		Metadata:   GetObjectMeta(crd),
-		Spec: CustomResourceDefinitionSpec{
-			Group:    crd.Spec.Group,
-			Names:    *GetCustomResourceDefinitionNames(crd.Spec.Names),
-			Scope:    GetResourceScope(crd.Spec.Scope),
-			Versions: GetCustomResourceDefinitionVersions(crd.Spec.Versions),
-		},
-		Status:       GetCustomResourceDefinitionStatus(crd.Status),
-		Unstructured: unstruct(crd),
-	}
-}
-
 // GetKubernetesResource from the supplied unstructured Kubernetes resource.
 // GetKubernetesResource attempts to determine what type of resource the
 // unstructured data contains (e.g. a managed resource, a provider, etc) and

--- a/internal/graph/model/common_test.go
+++ b/internal/graph/model/common_test.go
@@ -111,7 +111,7 @@ func TestGetGenericResource(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetGenericResource(tc.u)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(GenericResource{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(GenericResource{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetGenericResource(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -212,7 +212,7 @@ func TestGetSecret(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetSecret(tc.s)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Secret{}, "Unstructured"), cmp.AllowUnexported(Secret{}, ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Secret{}, "PavedAccess"), cmp.AllowUnexported(Secret{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -310,7 +310,7 @@ func TestGetConfigMap(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetConfigMap(tc.cm)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigMap{}, "Unstructured"), cmp.AllowUnexported(ConfigMap{}, ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigMap{}, "PavedAccess"), cmp.AllowUnexported(ConfigMap{}, ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetSecret(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -421,7 +421,7 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetCustomResourceDefinition(tc.crd)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CustomResourceDefinition{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(CustomResourceDefinition{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetCustomResourceDefinition(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -431,20 +431,20 @@ func TestGetCustomResourceDefinition(t *testing.T) {
 func TestGetKubernetesResource(t *testing.T) {
 	ignore := []cmp.Option{
 		cmp.AllowUnexported(Secret{}, ConfigMap{}, ObjectMeta{}),
-		cmpopts.IgnoreFields(ManagedResource{}, "Unstructured"),
-		cmpopts.IgnoreFields(ProviderConfig{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResource{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResourceClaim{}, "Unstructured"),
-		cmpopts.IgnoreFields(Provider{}, "Unstructured"),
-		cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"),
-		cmpopts.IgnoreFields(Configuration{}, "Unstructured"),
-		cmpopts.IgnoreFields(ConfigurationRevision{}, "Unstructured"),
-		cmpopts.IgnoreFields(CompositeResourceDefinition{}, "Unstructured"),
-		cmpopts.IgnoreFields(Composition{}, "Unstructured"),
-		cmpopts.IgnoreFields(CustomResourceDefinition{}, "Unstructured"),
-		cmpopts.IgnoreFields(Secret{}, "Unstructured"),
-		cmpopts.IgnoreFields(ConfigMap{}, "Unstructured"),
-		cmpopts.IgnoreFields(GenericResource{}, "Unstructured"),
+		cmpopts.IgnoreFields(ManagedResource{}, "PavedAccess"),
+		cmpopts.IgnoreFields(ProviderConfig{}, "PavedAccess"),
+		cmpopts.IgnoreFields(CompositeResource{}, "PavedAccess"),
+		cmpopts.IgnoreFields(CompositeResourceClaim{}, "PavedAccess"),
+		cmpopts.IgnoreFields(Provider{}, "PavedAccess"),
+		cmpopts.IgnoreFields(ProviderRevision{}, "PavedAccess"),
+		cmpopts.IgnoreFields(Configuration{}, "PavedAccess"),
+		cmpopts.IgnoreFields(ConfigurationRevision{}, "PavedAccess"),
+		cmpopts.IgnoreFields(CompositeResourceDefinition{}, "PavedAccess"),
+		cmpopts.IgnoreFields(Composition{}, "PavedAccess"),
+		cmpopts.IgnoreFields(CustomResourceDefinition{}, "PavedAccess"),
+		cmpopts.IgnoreFields(Secret{}, "PavedAccess"),
+		cmpopts.IgnoreFields(ConfigMap{}, "PavedAccess"),
+		cmpopts.IgnoreFields(GenericResource{}, "PavedAccess"),
 	}
 
 	dp := DeletionPolicyDelete

--- a/internal/graph/model/composite.go
+++ b/internal/graph/model/composite.go
@@ -20,6 +20,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 
 	"github.com/upbound/xgql/internal/unstructured"
 )
@@ -74,8 +75,10 @@ func GetCompositeResource(u *kunstructured.Unstructured) CompositeResource {
 			ResourceReferences:               xr.GetResourceReferences(),
 			WriteConnectionSecretToReference: xr.GetWriteConnectionSecretToReference(),
 		},
-		Status:       GetCompositeResourceStatus(xr),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetCompositeResourceStatus(xr),
+		PavedAccess: PavedAccess{
+			Paved: fieldpath.Pave(u.Object),
+		},
 	}
 }
 
@@ -140,7 +143,9 @@ func GetCompositeResourceClaim(u *kunstructured.Unstructured) CompositeResourceC
 			ResourceReference:                xrc.GetResourceReference(),
 			WriteConnectionSecretToReference: delocalize(xrc.GetWriteConnectionSecretToReference(), xrc.GetNamespace()),
 		},
-		Status:       GetCompositeResourceClaimStatus(xrc),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetCompositeResourceClaimStatus(xrc),
+		PavedAccess: PavedAccess{
+			Paved: fieldpath.Pave(u.Object),
+		},
 	}
 }

--- a/internal/graph/model/composite_test.go
+++ b/internal/graph/model/composite_test.go
@@ -104,7 +104,7 @@ func TestGetCompositeResource(t *testing.T) {
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,
-				cmpopts.IgnoreFields(CompositeResource{}, "Unstructured"),
+				cmpopts.IgnoreFields(CompositeResource{}, "PavedAccess"),
 				cmpopts.EquateApproxTime(1*time.Second),
 				cmp.AllowUnexported(ObjectMeta{}),
 			); diff != "" {
@@ -184,7 +184,7 @@ func TestGetCompositeResourceClaim(t *testing.T) {
 
 			// metav1.Time trims timestamps to second resolution.
 			if diff := cmp.Diff(tc.want, got,
-				cmpopts.IgnoreFields(CompositeResourceClaim{}, "Unstructured"),
+				cmpopts.IgnoreFields(CompositeResourceClaim{}, "PavedAccess"),
 				cmpopts.EquateApproxTime(1*time.Second),
 				cmp.AllowUnexported(ObjectMeta{}),
 			); diff != "" {

--- a/internal/graph/model/event.go
+++ b/internal/graph/model/event.go
@@ -42,11 +42,13 @@ func GetEvent(e *corev1.Event) Event {
 			Namespace:  e.GetNamespace(),
 			Name:       e.GetName(),
 		},
-		APIVersion:        e.APIVersion,
-		Kind:              e.Kind,
-		Metadata:          GetObjectMeta(e),
-		Type:              GetEventType(e.Type),
-		Unstructured:      unstruct(e),
+		APIVersion: e.APIVersion,
+		Kind:       e.Kind,
+		Metadata:   GetObjectMeta(e),
+		Type:       GetEventType(e.Type),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(e),
+		},
 		InvolvedObjectRef: e.InvolvedObject,
 	}
 

--- a/internal/graph/model/event_test.go
+++ b/internal/graph/model/event_test.go
@@ -91,7 +91,7 @@ func TestGetEvent(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetEvent(tc.s)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Event{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Event{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetEvent(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/fieldpath.go
+++ b/internal/graph/model/fieldpath.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SkipUnstructured is a marker type. It is used in the schema via a `@goType` directive
+// to change all "unstructured" fields to this type and make them embedded. This prevents
+// gqlgen from generating resolver logic for these fields and instead makes it delegate
+// resolutions to PavedAccess, which is also embedded via the `@goType` directive.
+type SkipUnstructured interface{}
+
+// PavedAccess is an embedded resolver for "unstructured" and "fieldPath" fields.
+// It is embedded in generated types via a `@goType` directive.
+type PavedAccess struct {
+	*fieldpath.Paved
+}
+
+// Unstructured implements the "unstructured" field and returns the JSON representation
+// of the entire object.
+func (f PavedAccess) Unstructured() []byte {
+	return raw(f.Paved)
+}
+
+// FieldPath implements the "fieldPath" field and returns the JSON representation
+// of the value at the given path.
+func (f PavedAccess) FieldPath(path *string) ([]byte, error) {
+	if path == nil || len(*path) == 0 {
+		return f.Unstructured(), nil
+	}
+	return fieldPath(f.Paved, *path)
+}
+
+// raw returns the supplied object as unstructured JSON bytes. It panics if
+// the object cannot be marshalled as JSON, which _should_ only happen if this
+// program is fundamentally broken - e.g. trying to use a weird runtime.Object.
+func raw(paved *fieldpath.Paved) []byte {
+	out, err := json.Marshal(paved)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+// fieldPathWildcard expands the wildcard field path and returns the values at
+// the resulting field paths for the supplied object as JSON bytes. It panics if
+// the object cannot be marshalled as JSON, which _should_ only happen if this
+// program is fundamentally broken.
+func fieldPathWildcard(paved *fieldpath.Paved, path string) ([]byte, error) {
+	arrayFieldPaths, err := paved.ExpandWildcards(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(arrayFieldPaths) == 0 {
+		return nil, errors.Errorf("cannot expand path %q", path)
+	}
+
+	array := make([]interface{}, 0, len(arrayFieldPaths))
+	for _, arrayFieldPath := range arrayFieldPaths {
+		v, err := paved.GetValue(arrayFieldPath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot get value at path %q", arrayFieldPath)
+		}
+		array = append(array, v)
+	}
+	out, err := json.Marshal(array)
+	if err != nil {
+		panic(err)
+	}
+	return out, nil
+}
+
+// fieldPath returns the value at the supplied field path for the supplied
+// object as JSON bytes. It panics if the object cannot be marshalled as JSON,
+// which _should_ only happen if this program is fundamentally broken.
+func fieldPath(paved *fieldpath.Paved, path string) ([]byte, error) {
+	if strings.Contains(path, "[*]") {
+		return fieldPathWildcard(paved, path)
+	}
+	v, err := paved.GetValue(path)
+	if err != nil {
+		return nil, err
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return out, nil
+}
+
+func paveObject(o runtime.Object) *fieldpath.Paved {
+	p, err := fieldpath.PaveObject(o)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}

--- a/internal/graph/model/fieldpath_test.go
+++ b/internal/graph/model/fieldpath_test.go
@@ -1,0 +1,208 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	kextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+
+	"github.com/upbound/xgql/internal/unstructured"
+)
+
+func TestPavedAccess_FieldPath(t *testing.T) {
+	transition := time.Now()
+	crd := func() *unstructured.CustomResourceDefinition {
+		crd := unstructured.NewCRD()
+		crd.SetName("cool")
+		crd.SetSpecGroup("group")
+		crd.SetSpecNames(kextv1.CustomResourceDefinitionNames{
+			Plural:     "clusterexamples",
+			Singular:   "clusterexample",
+			ShortNames: []string{"cex"},
+			Kind:       "ClusterExample",
+			ListKind:   "ClusterExampleList",
+			Categories: []string{"example"},
+		})
+		crd.SetSpecScope(kextv1.NamespaceScoped)
+		crd.SetSpecVersions([]kextv1.CustomResourceDefinitionVersion{{
+			Name:   "v1",
+			Served: true,
+			Schema: &kextv1.CustomResourceValidation{
+				OpenAPIV3Schema: &kextv1.JSONSchemaProps{},
+			},
+		}})
+		crd.SetStatus(kextv1.CustomResourceDefinitionStatus{
+			Conditions: []kextv1.CustomResourceDefinitionCondition{{
+				Type:               kextv1.Established,
+				Reason:             "VeryCoolCRD",
+				Message:            "So cool",
+				LastTransitionTime: metav1.NewTime(transition),
+			}},
+		})
+		return crd
+	}()
+	// TODO(avalanche123): we can't reproduce exact errors from fieldpath.
+	// the errNotFound is unexported and doesn't have a constructor.
+	// Additionally, the type information from top level call to cmp.Diff
+	// is not getting propagated correctly, so we use a FilterValue+Transformer
+	// instead of a Comparer here. see https://github.com/google/go-cmp/issues/161.
+	equateErrorMessage := func() cmp.Option {
+		return cmp.FilterValues(func(x, y any) bool {
+			_, ok1 := x.(error)
+			_, ok2 := y.(error)
+			return ok1 && ok2
+		}, cmp.Transformer("T", func(e any) string {
+			return e.(error).Error()
+		}))
+	}
+	transformJSON := cmpopts.AcyclicTransformer("ToJSON", func(in any) []byte {
+		if in == nil {
+			return nil
+		}
+		if out, ok := in.([]byte); ok {
+			if len(out) == 0 {
+				return nil
+			}
+			return out
+		}
+		out, err := json.Marshal(in)
+		if err != nil {
+			panic(err)
+		}
+		return out
+	})
+	type args struct {
+		fieldPath *string
+		object    runtime.Object
+	}
+	type want struct {
+		out any
+		err error
+	}
+	tests := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"Success": {
+			reason: "Returns value at fieldPath.",
+			args: args{
+				fieldPath: pointer.String("metadata.name"),
+				object:    crd,
+			},
+			want: want{
+				out: "cool",
+			},
+		},
+		"Wildcard": {
+			reason: "Returns all values in expanded wildcard paths.",
+			args: args{
+				fieldPath: pointer.String("spec.status.conditions[*].reason"),
+				object:    crd,
+			},
+			want: want{
+				out: []string{"VeryCoolCRD"},
+			},
+		},
+		"WrongPath": {
+			reason: "Returns nil.",
+			args: args{
+				fieldPath: pointer.String("bad.field.path"),
+				object:    crd,
+			},
+			want: want{
+				out: []byte(nil),
+				err: fmt.Errorf("%s: %s", "bad", "no such field"),
+			},
+		},
+		"EmptyPath": {
+			reason: "Returns the entire object.",
+			args: args{
+				object: crd,
+			},
+			want: want{
+				out: map[string]any{
+					"apiVersion": "apiextensions.k8s.io/v1",
+					"kind":       "CustomResourceDefinition",
+					"metadata": map[string]string{
+						"name": "cool",
+					},
+					"spec": map[string]any{
+						"group": "group",
+						"names": map[string]any{
+							"plural":     "clusterexamples",
+							"singular":   "clusterexample",
+							"shortNames": []string{"cex"},
+							"kind":       "ClusterExample",
+							"listKind":   "ClusterExampleList",
+							"categories": []string{"example"},
+						},
+						"scope": "Namespaced",
+						"status": map[string]any{
+							"acceptedNames": map[string]string{
+								"kind":   "",
+								"plural": "",
+							},
+							"conditions": []map[string]any{
+								{
+									"status":             "",
+									"type":               kextv1.Established,
+									"reason":             "VeryCoolCRD",
+									"message":            "So cool",
+									"lastTransitionTime": transition.UTC().Format(time.RFC3339),
+								},
+							},
+							"storedVersions": nil,
+						},
+						"versions": []map[string]any{
+							{
+								"name": "v1",
+								"schema": map[string]any{
+									"openAPIV3Schema": map[string]any{},
+								},
+								"served":  true,
+								"storage": false,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := PavedAccess{
+				Paved: paveObject(tc.args.object),
+			}
+			out, err := f.FieldPath(tc.args.fieldPath)
+			if diff := cmp.Diff(tc.want.err, err, equateErrorMessage()); diff != "" {
+				t.Errorf("\n%s\nPavedAccess.FieldPath(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.out, out, transformJSON); diff != "" {
+				t.Errorf("\n%s\nPavedAccess.FieldPath(...): -want, +got:\n%s", tc.reason, diff)
+				return
+			}
+		})
+	}
+}

--- a/internal/graph/model/generated.go
+++ b/internal/graph/model/generated.go
@@ -63,7 +63,77 @@ type CompositeResource struct {
 	// The observed state of this resource.
 	Status *CompositeResourceStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -89,7 +159,77 @@ type CompositeResourceClaim struct {
 	// The observed state of this resource.
 	Status *CompositeResourceClaimStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -160,7 +300,77 @@ type CompositeResourceDefinition struct {
 	// The observed state of this resource.
 	Status *CompositeResourceDefinitionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The generated `CustomResourceDefinition` for this XRD
@@ -291,7 +501,77 @@ type Composition struct {
 	// The observed state of this resource.
 	Status *CompositionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -360,7 +640,77 @@ type ConfigMap struct {
 	// The data stored in this config map.
 	data map[string]string `json:"data,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -384,7 +734,77 @@ type Configuration struct {
 	// The observed state of this resource.
 	Status *ConfigurationStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// Revisions of this configuration.
@@ -420,7 +840,77 @@ type ConfigurationRevision struct {
 	// The observed state of this resource.
 	Status *ConfigurationRevisionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -573,7 +1063,77 @@ type CustomResourceDefinition struct {
 	// The observed state of this resource.
 	Status *CustomResourceDefinitionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// Custom resources defined by this CRD
@@ -725,7 +1285,77 @@ type Event struct {
 	// The time at which this event was most recently recorded.
 	LastTime *time.Time `json:"lastTime,omitempty"`
 	// An unstructured JSON representation of the event.
-	Unstructured      []byte              `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess       `json:"fieldPath"`
 	InvolvedObjectRef v11.ObjectReference `json:"-"`
 }
 
@@ -760,7 +1390,77 @@ type GenericResource struct {
 	// Metadata that is common to all Kubernetes API resources.
 	Metadata ObjectMeta `json:"metadata"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -807,7 +1507,77 @@ type ManagedResource struct {
 	// The observed state of this resource.
 	Status *ManagedResourceStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -921,7 +1691,77 @@ type Provider struct {
 	// The observed state of this resource.
 	Status *ProviderStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// Revisions of this provider.
@@ -948,7 +1788,77 @@ type ProviderConfig struct {
 	// The observed state of this resource.
 	Status *ProviderConfigStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 	// The definition of this resource.
@@ -998,7 +1908,77 @@ type ProviderRevision struct {
 	// The observed state of this resource.
 	Status *ProviderRevisionStatus `json:"status,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }
@@ -1114,7 +2094,77 @@ type Secret struct {
 	// The data stored in this secret. Values are not base64 encoded.
 	data map[string]string `json:"data,omitempty"`
 	// An unstructured JSON representation of the underlying Kubernetes resource.
-	Unstructured []byte `json:"unstructured"`
+	SkipUnstructured `json:"unstructured"`
+	// A JSON representation of a field within the underlying Kubernetes resource.
+	//
+	// API conventions describe the syntax as:
+	// > standard JavaScript syntax for accessing that field, assuming the JSON
+	// > object was transformed into a JavaScript object, without the leading dot,
+	// > such as `metadata.name`.
+	//
+	// Valid examples:
+	//
+	// * `metadata.name`
+	// * `spec.containers[0].name`
+	// * `data[.config.yml]`
+	// * `metadata.annotations['crossplane.io/external-name']`
+	// * `spec.items[0][8]`
+	// * `apiVersion`
+	// * `[42]`
+	// * `spec.containers[*].args[*]` - Supports wildcard expansion.
+	//
+	// Invalid examples:
+	//
+	// * `.metadata.name` - Leading period.
+	// * `metadata..name` - Double period.
+	// * `metadata.name.` - Trailing period.
+	// * `spec.containers[]` - Empty brackets.
+	// * `spec.containers.[0].name` - Period before open bracket.
+	//
+	// Wildcards support:
+	//
+	// For an object with the following data:
+	//
+	// ```json
+	// {
+	//   "spec": {
+	//     "containers": [
+	//       {
+	//         "name": "cool",
+	//         "image": "latest",
+	//         "args": [
+	//           "start",
+	//           "now",
+	//           "debug"
+	//         ]
+	//       }
+	//     ]
+	//   }
+	// }
+	// ```
+	//
+	// The wildcard `spec.containers[*].args[*]` will be expanded to:
+	//
+	// ```json
+	// [
+	//   "spec.containers[0].args[0]",
+	//   "spec.containers[0].args[1]",
+	//   "spec.containers[0].args[2]",
+	// ]
+	// ```
+	//
+	// And the following result will be returned:
+	//
+	// ```json
+	// [
+	//   "start",
+	//   "now",
+	//   "debug"
+	// ]
+	// ```
+	//
+	// https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+	PavedAccess `json:"fieldPath"`
 	// Events pertaining to this resource.
 	Events EventConnection `json:"events"`
 }

--- a/internal/graph/model/managed.go
+++ b/internal/graph/model/managed.go
@@ -18,6 +18,7 @@ import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 
 	"github.com/upbound/xgql/internal/unstructured"
 )
@@ -79,7 +80,9 @@ func GetManagedResource(u *kunstructured.Unstructured) ManagedResource {
 			ProviderConfigRef:                GetProviderConfigReference(mg.GetProviderConfigReference()),
 			DeletionPolicy:                   GetDeletionPolicy(mg.GetDeletionPolicy()),
 		},
-		Status:       GetManagedResourceStatus(mg),
-		Unstructured: bytesForUnstructured(u),
+		Status: GetManagedResourceStatus(mg),
+		PavedAccess: PavedAccess{
+			Paved: fieldpath.Pave(u.Object),
+		},
 	}
 }

--- a/internal/graph/model/managed_test.go
+++ b/internal/graph/model/managed_test.go
@@ -90,7 +90,7 @@ func TestGetManagedResource(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := GetManagedResource(tc.u)
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ManagedResource{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ManagedResource{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetManagedResource(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/package.go
+++ b/internal/graph/model/package.go
@@ -112,8 +112,10 @@ func GetProvider(p *pkgv1.Provider) Provider {
 			IgnoreCrossplaneConstraints: p.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    p.Spec.SkipDependencyResolution,
 		},
-		Status:       GetProviderStatus(p.Status),
-		Unstructured: unstruct(p),
+		Status: GetProviderStatus(p.Status),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(p),
+		},
 	}
 }
 
@@ -164,8 +166,10 @@ func GetProviderRevision(pr *pkgv1.ProviderRevision) ProviderRevision {
 			IgnoreCrossplaneConstraints: pr.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    pr.Spec.SkipDependencyResolution,
 		},
-		Status:       GetProviderRevisionStatus(pr.Status),
-		Unstructured: unstruct(pr),
+		Status: GetProviderRevisionStatus(pr.Status),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(pr),
+		},
 	}
 }
 
@@ -204,8 +208,10 @@ func GetConfiguration(c *pkgv1.Configuration) Configuration {
 			IgnoreCrossplaneConstraints: c.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    c.Spec.SkipDependencyResolution,
 		},
-		Status:       GetConfigurationStatus(c.Status),
-		Unstructured: unstruct(c),
+		Status: GetConfigurationStatus(c.Status),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(c),
+		},
 	}
 }
 
@@ -245,7 +251,9 @@ func GetConfigurationRevision(cr *pkgv1.ConfigurationRevision) ConfigurationRevi
 			IgnoreCrossplaneConstraints: cr.Spec.IgnoreCrossplaneConstraints,
 			SkipDependencyResolution:    cr.Spec.SkipDependencyResolution,
 		},
-		Status:       GetConfigurationRevisionStatus(cr.Status),
-		Unstructured: unstruct(cr),
+		Status: GetConfigurationRevisionStatus(cr.Status),
+		PavedAccess: PavedAccess{
+			Paved: paveObject(cr),
+		},
 	}
 }

--- a/internal/graph/model/package_test.go
+++ b/internal/graph/model/package_test.go
@@ -111,7 +111,7 @@ func TestGetProvider(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetProvider(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Provider{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Provider{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProvider(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -213,7 +213,7 @@ func TestGetProviderRevision(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetProviderRevision(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderRevision{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -303,7 +303,7 @@ func TestGetConfiguration(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetConfiguration(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Configuration{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(Configuration{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfiguration(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})
@@ -405,7 +405,7 @@ func TestGetConfigurationRevision(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := GetConfigurationRevision(tc.cfg)
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigurationRevision{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ConfigurationRevision{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetConfigurationRevision(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/providerconfig.go
+++ b/internal/graph/model/providerconfig.go
@@ -17,6 +17,7 @@ package model
 import (
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/upbound/xgql/internal/unstructured"
@@ -47,10 +48,12 @@ func GetProviderConfig(u *kunstructured.Unstructured) ProviderConfig {
 			Name:       pc.GetName(),
 		},
 
-		APIVersion:   pc.GetAPIVersion(),
-		Kind:         pc.GetKind(),
-		Metadata:     GetObjectMeta(pc),
-		Status:       GetProviderConfigStatus(pc),
-		Unstructured: bytesForUnstructured(u),
+		APIVersion: pc.GetAPIVersion(),
+		Kind:       pc.GetKind(),
+		Metadata:   GetObjectMeta(pc),
+		Status:     GetProviderConfigStatus(pc),
+		PavedAccess: PavedAccess{
+			Paved: fieldpath.Pave(u.Object),
+		},
 	}
 }

--- a/internal/graph/model/providerconfig_test.go
+++ b/internal/graph/model/providerconfig_test.go
@@ -75,7 +75,7 @@ func TestGetProviderConfig(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := GetProviderConfig(tc.u)
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderConfig{}, "Unstructured"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(ProviderConfig{}, "PavedAccess"), cmp.AllowUnexported(ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nGetProviderConfig(...): -want, +got\n:%s", tc.reason, diff)
 			}
 		})

--- a/internal/graph/model/util.go
+++ b/internal/graph/model/util.go
@@ -15,35 +15,11 @@
 package model
 
 import (
-	"github.com/go-json-experiment/json"
-
 	"github.com/pkg/errors"
 	kunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-// unstruct returns the supplied object as unstructured JSON bytes. It panics if
-// the object cannot be marshalled as JSON, which _should_ only happen if this
-// program is fundamentally broken - e.g. trying to use a weird runtime.Object.
-func unstruct(obj runtime.Object) []byte {
-	out, err := json.Marshal(obj)
-	if err != nil {
-		panic(err)
-	}
-	return out
-}
-
-// bytesForUnstructured returns the supplied unstructured.Unstructured as JSON
-// bytes. It panics if the object cannot be marshalled as JSON, which _should_
-// only happen if this program is fundamentally broken.
-func bytesForUnstructured(u *kunstructured.Unstructured) []byte {
-	out, err := json.Marshal(u.Object)
-	if err != nil {
-		panic(err)
-	}
-	return out
-}
 
 func convert(from *kunstructured.Unstructured, to runtime.Object) error {
 	c := runtime.DefaultUnstructuredConverter

--- a/internal/graph/resolvers/apiextensions_test.go
+++ b/internal/graph/resolvers/apiextensions_test.go
@@ -143,7 +143,7 @@ func TestCompositeResourceCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -258,7 +258,7 @@ func TestCompositeResourceClaimCrd(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crd, got, cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\nq.CompositeResourceClaimCrd(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -746,7 +746,7 @@ func TestXRDDefinedCompositeResources(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.crc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.CompositeResource{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResources(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -1423,7 +1423,7 @@ func TestXRDDefinedCompositeResourceClaims(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.crcc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -1530,7 +1530,7 @@ func TestCompositeResourceDefinitionSpecDefaultComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.DefaultComposition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.DefaultComposition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1636,7 +1636,7 @@ func TestCompositeResourceDefinitionSpecEnforcedComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.EnforcedComposition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.EnforcedComposition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/common_test.go
+++ b/internal/graph/resolvers/common_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -231,7 +232,7 @@ func TestCRDDefinedResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.DefinedResources(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.DefinedResources(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/composite_test.go
+++ b/internal/graph/resolvers/composite_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	extv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 
@@ -183,7 +184,7 @@ func TestCompositeResourceDefinition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -307,7 +308,7 @@ func TestCompositeResourceSpecComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -370,7 +371,7 @@ func TestCompositeResourceSpecCompositionRef(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -494,7 +495,7 @@ func TestCompositeResourceSpecClaim(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrc, got, cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -559,7 +560,7 @@ func TestCompositeResourceSpecClaimRef(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ClaimRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ClaimRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -707,7 +708,7 @@ func TestCompositeResourceSpecResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -831,7 +832,7 @@ func TestCompositeResourceSpecConnectionSecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -897,7 +898,7 @@ func TestCompositeResourceSpecWriteConnectionSecretToReference(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1047,7 +1048,7 @@ func TestCompositeResourceClaimDefinition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrd, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1171,7 +1172,7 @@ func TestCompositeResourceClaimSpecComposition(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cmp, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Composition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1234,7 +1235,7 @@ func TestCompositeResourceClaimSpecCompositionRef(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.CompositionRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1358,7 +1359,7 @@ func TestCompositeResourceClaimSpecResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xr, got, cmpopts.IgnoreFields(model.CompositeResource{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.Claim(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1423,7 +1424,7 @@ func TestCompositeResourceClaimSpecResourceReference(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ResourceRef(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ResourceRef(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1547,7 +1548,7 @@ func TestCompositeResourceClaimSpecConnectionSecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1613,7 +1614,7 @@ func TestCompositeResourceClaimSpecWriteConnectionSecretToReference(t *testing.T
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ref, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.WriteConnectionSecretToReference(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/configuration_test.go
+++ b/internal/graph/resolvers/configuration_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	extv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
@@ -162,7 +163,7 @@ func TestConfigurationRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.crc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.crc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -306,7 +307,7 @@ func TestConfigurationActiveRevision(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -466,7 +467,7 @@ func TestConfigurationRevisionStatusObjects(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/event_test.go
+++ b/internal/graph/resolvers/event_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -154,7 +155,7 @@ func TestEvent(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Resolve(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.ec, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.ec, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Resolve(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -358,7 +359,7 @@ func TestEventInvolvedObject(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.InvolvedObject(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/managed_test.go
+++ b/internal/graph/resolvers/managed_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	"github.com/upbound/xgql/internal/auth"
@@ -231,7 +232,7 @@ func TestManagedResourceDefinition(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -338,7 +339,7 @@ func TestManagedResourceSpecConnectionSecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConnectionSecret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/mutation_test.go
+++ b/internal/graph/resolvers/mutation_test.go
@@ -246,7 +246,7 @@ func TestCreateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.CreateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -420,7 +420,7 @@ func TestUpdateKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.UpdateKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -522,7 +522,7 @@ func TestDeleteKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.payload, got, cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.DeleteKubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/internal/graph/resolvers/objectmeta.go
+++ b/internal/graph/resolvers/objectmeta.go
@@ -16,6 +16,7 @@ package resolvers
 
 import (
 	"context"
+	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -48,25 +49,38 @@ func (r *objectMeta) Owners(ctx context.Context, obj *model.ObjectMeta) (model.O
 	}
 
 	owners := make([]model.Owner, 0, len(obj.OwnerReferences))
+	// Collect all concurrently.
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
 	for _, ref := range obj.OwnerReferences {
-		u := &kunstructured.Unstructured{}
-		u.SetAPIVersion(ref.APIVersion)
-		u.SetKind(ref.Kind)
+		ref := ref // So we don't reference the loop variable.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			u := &kunstructured.Unstructured{}
+			u.SetAPIVersion(ref.APIVersion)
+			u.SetKind(ref.Kind)
 
-		nn := types.NamespacedName{Namespace: pointer.StringDeref(obj.Namespace, ""), Name: ref.Name}
-		if err := c.Get(ctx, nn, u); err != nil {
-			graphql.AddError(ctx, errors.Wrap(err, errGetOwner))
-			continue
-		}
+			nn := types.NamespacedName{Namespace: pointer.StringDeref(obj.Namespace, ""), Name: ref.Name}
+			if err := c.Get(ctx, nn, u); err != nil {
+				graphql.AddError(ctx, errors.Wrap(err, errGetOwner))
+				return
+			}
 
-		kr, err := model.GetKubernetesResource(u)
-		if err != nil {
-			graphql.AddError(ctx, errors.Wrap(err, errModelOwner))
-			continue
-		}
+			kr, err := model.GetKubernetesResource(u)
+			if err != nil {
+				graphql.AddError(ctx, errors.Wrap(err, errModelOwner))
+				return
+			}
 
-		owners = append(owners, model.Owner{Controller: ref.Controller, Resource: kr})
+			mu.Lock()
+			defer mu.Unlock()
+			owners = append(owners, model.Owner{Controller: ref.Controller, Resource: kr})
+		}()
 	}
+	wg.Wait()
 
 	return model.OwnerConnection{Nodes: owners, TotalCount: len(owners)}, nil
 }

--- a/internal/graph/resolvers/objectmeta_test.go
+++ b/internal/graph/resolvers/objectmeta_test.go
@@ -141,7 +141,7 @@ func TestObjectMetaOwners(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.oc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Owners(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -286,7 +286,7 @@ func TestObjectMetaController(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.kr, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Controller(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/provider.go
+++ b/internal/graph/resolvers/provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
@@ -163,6 +164,11 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 		Nodes: make([]model.KubernetesResource, 0, len(obj.ObjectRefs)),
 	}
 
+	// Collect all concurrently.
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
 	for _, ref := range obj.ObjectRefs {
 		// Crossplane lints provider packages to ensure they only contain CRDs,
 		// but this isn't enforced at the API level. We filter out anything that
@@ -174,15 +180,23 @@ func (r *providerRevisionStatus) Objects(ctx context.Context, obj *model.Provide
 			continue
 		}
 
-		crd := xunstructured.NewCRD()
-		if err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, crd.GetUnstructured()); err != nil {
-			graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
-			continue
-		}
+		ref := ref // So we don't take the address of a range variable.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			crd := xunstructured.NewCRD()
+			if err := c.Get(ctx, types.NamespacedName{Name: ref.Name}, crd.GetUnstructured()); err != nil {
+				graphql.AddError(ctx, errors.Wrap(err, errGetCRD))
+				return
+			}
 
-		out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd))
-		out.TotalCount++
+			mu.Lock()
+			defer mu.Unlock()
+			out.Nodes = append(out.Nodes, model.GetCustomResourceDefinition(crd))
+			out.TotalCount++
+		}()
 	}
+	wg.Wait()
 
 	return *out, nil
 }

--- a/internal/graph/resolvers/provider_test.go
+++ b/internal/graph/resolvers/provider_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
@@ -163,7 +164,7 @@ func TestProviderRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -307,7 +308,7 @@ func TestProviderActiveRevision(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pr, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.ActiveRevision(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -447,7 +448,7 @@ func TestProviderRevisionStatusObjects(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.krc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Objects(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/providerconfig_test.go
+++ b/internal/graph/resolvers/providerconfig_test.go
@@ -229,7 +229,7 @@ func TestProviderConfigDefinition(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.mrd, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\ns.Definition(...): -want, +got:\n%s\n", tc.reason, diff)
 			}

--- a/internal/graph/resolvers/query_test.go
+++ b/internal/graph/resolvers/query_test.go
@@ -220,10 +220,10 @@ func TestCrossplaneResourceTree(t *testing.T) {
 			}
 
 			diffOptions := []cmp.Option{
-				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.CompositeResource{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.ManagedResource{}, "Unstructured"),
-				cmpopts.IgnoreFields(model.ProviderConfig{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.CompositeResourceClaim{}, "PavedAccess"),
+				cmpopts.IgnoreFields(model.CompositeResource{}, "PavedAccess"),
+				cmpopts.IgnoreFields(model.ManagedResource{}, "PavedAccess"),
+				cmpopts.IgnoreFields(model.ProviderConfig{}, "PavedAccess"),
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
 			}
 
@@ -316,7 +316,7 @@ func TestQueryKubernetesResource(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "Unstructured"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.kr, got, cmpopts.IgnoreFields(model.GenericResource{}, "PavedAccess"), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
 				t.Errorf("\n%s\ns.KubernetesResource(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -504,7 +504,7 @@ func TestQueryKubernetesResources(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.krc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.DefinedCompositeResourceClaims(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -594,7 +594,7 @@ func TestQuerySecret(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.Secret(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.sec, got, cmp.AllowUnexported(model.Secret{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.Secret(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -684,7 +684,7 @@ func TestQueryConfigMap(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\ns.ConfigMap(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cm, got, cmp.AllowUnexported(model.ConfigMap{}), cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cm, got, cmp.AllowUnexported(model.ConfigMap{}), cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\ns.ConfigMap(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -779,7 +779,7 @@ func TestQueryProviders(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Providers(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Providers(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -968,7 +968,7 @@ func TestQueryProviderRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1137,7 +1137,7 @@ func TestQueryCustomResourceDefinitions(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.xrdc, got,
 				cmpopts.IgnoreUnexported(model.ObjectMeta{}),
-				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "Unstructured"),
+				cmpopts.IgnoreFields(model.CustomResourceDefinition{}, "PavedAccess"),
 			); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
@@ -1233,7 +1233,7 @@ func TestQueryConfigurations(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1422,7 +1422,7 @@ func TestQueryConfigurationRevisions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.pc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Revisions(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1616,7 +1616,7 @@ func TestQueryCompositeResourceDefinitions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.xrdc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.xrdc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
@@ -1811,7 +1811,7 @@ func TestQueryCompositions(t *testing.T) {
 			if diff := cmp.Diff(tc.want.errs, errs, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want GraphQL errors, +got GraphQL errors:\n%s\n", tc.reason, diff)
 			}
-			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{})); diff != "" {
+			if diff := cmp.Diff(tc.want.cc, got, cmpopts.IgnoreUnexported(model.ObjectMeta{}, fieldpath.Paved{})); diff != "" {
 				t.Errorf("\n%s\nq.Configurations(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})

--- a/schema/apiextensions.gql
+++ b/schema/apiextensions.gql
@@ -23,6 +23,91 @@ type CompositeResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -340,6 +425,91 @@ type Composition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/common.gql
+++ b/schema/common.gql
@@ -43,6 +43,91 @@ interface KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection!
@@ -90,6 +175,91 @@ type GenericResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -359,6 +529,91 @@ type Event implements Node {
 
   "An unstructured JSON representation of the event."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 }
 
 """
@@ -421,6 +676,91 @@ type Secret implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   """
   Events pertaining to this resource.
@@ -462,6 +802,91 @@ type ConfigMap implements Node & KubernetesResource {
   An unstructured JSON representation of the underlying Kubernetes resource.
   """
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   # TODO(negz): Support binaryData too? What would the return value be?
 
@@ -526,6 +951,91 @@ type CustomResourceDefinition implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/composite.gql
+++ b/schema/composite.gql
@@ -24,6 +24,91 @@ type CompositeResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -126,6 +211,91 @@ type CompositeResourceClaim implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/configuration.gql
+++ b/schema/configuration.gql
@@ -22,6 +22,91 @@ type Configuration implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -140,6 +225,91 @@ type ConfigurationRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/directives.gql
+++ b/schema/directives.gql
@@ -7,6 +7,8 @@ directive @goField(
   forceResolver: Boolean
   name: String
   omittable: Boolean
+  type: String
+  embed: Boolean
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 directive @goTag(

--- a/schema/managed.gql
+++ b/schema/managed.gql
@@ -24,6 +24,91 @@ type ManagedResource implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/provider.gql
+++ b/schema/provider.gql
@@ -22,6 +22,91 @@ type Provider implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)
@@ -139,6 +224,91 @@ type ProviderRevision implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)

--- a/schema/providerconfig.gql
+++ b/schema/providerconfig.gql
@@ -20,6 +20,91 @@ type ProviderConfig implements Node & KubernetesResource {
 
   "An unstructured JSON representation of the underlying Kubernetes resource."
   unstructured: JSON!
+    @deprecated(reason: "Use `fieldPath` instead")
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.SkipUnstructured"
+      embed: true
+    )
+
+  """
+  A JSON representation of a field within the underlying Kubernetes resource.
+
+  API conventions describe the syntax as:
+  > standard JavaScript syntax for accessing that field, assuming the JSON
+  > object was transformed into a JavaScript object, without the leading dot,
+  > such as `metadata.name`.
+
+  Valid examples:
+
+  * `metadata.name`
+  * `spec.containers[0].name`
+  * `data[.config.yml]`
+  * `metadata.annotations['crossplane.io/external-name']`
+  * `spec.items[0][8]`
+  * `apiVersion`
+  * `[42]`
+  * `spec.containers[*].args[*]` - Supports wildcard expansion.
+
+  Invalid examples:
+
+  * `.metadata.name` - Leading period.
+  * `metadata..name` - Double period.
+  * `metadata.name.` - Trailing period.
+  * `spec.containers[]` - Empty brackets.
+  * `spec.containers.[0].name` - Period before open bracket.
+
+  Wildcards support:
+
+  For an object with the following data:
+
+  ```json
+  {
+    "spec": {
+      "containers": [
+        {
+          "name": "cool",
+          "image": "latest",
+          "args": [
+            "start",
+            "now",
+            "debug"
+          ]
+        }
+      ]
+    }
+  }
+  ```
+
+  The wildcard `spec.containers[*].args[*]` will be expanded to:
+
+  ```json
+  [
+    "spec.containers[0].args[0]",
+    "spec.containers[0].args[1]",
+    "spec.containers[0].args[2]",
+  ]
+  ```
+
+  And the following result will be returned:
+
+  ```json
+  [
+    "start",
+    "now",
+    "debug"
+  ]
+  ```
+
+  https://github.com/kubernetes/community/blob/61f3d0/contributors/devel/sig-architecture/api-conventions.md#selecting-fields
+  """
+  fieldPath(
+    "A path to a field within a Kubernetes object."
+    path: String
+  ): JSON!
+    @goField(
+      type: "github.com/upbound/xgql/internal/graph/model.PavedAccess"
+      embed: true
+    )
 
   "Events pertaining to this resource."
   events: EventConnection! @goField(forceResolver: true)


### PR DESCRIPTION
- remove unused method
- parallelize looping resolvers
- extend gqlgen's goType directive
- add fieldPath and deprecate unstructured

This PR supersedes #119 and #120 since I haven't noticed much performance gain
from generating unstructured json only if it has been requested in my testing.

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Add a new field `fieldPath` that deprecates `unstructured` and allows to be
exact in which data needs to be selected:

```gql
{
  name: fieldPath(path: "metadata.name")
  images: fieldPath(path: "spec.containers[*].image")
}
```

Some modification of gqlgen's code generation process was necessary to remove
the no longer used `Unstructured` field and enforce delegation for the "unstructured"
and "fieldPath" fields to the embedded `model.PavedAccess` field of generated
structs.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I've tested it both locally via playground and on a running MCP via console.

