### PR TITLE
minimize memory requirements of informer cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/urfave/cli/v2 v2.25.7 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	go.etcd.io/bbolt v1.3.7
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -97,7 +98,7 @@ require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
-	golang.org/x/sync v0.3.0 // indirect
+	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.12.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -734,6 +734,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
+go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
+go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5/go.mod h1:skWido08r9w6Lq/w70DO5XYIKMu4QFu1+4VsqLQuJy8=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=

--- a/internal/cache/bbolt_cache.go
+++ b/internal/cache/bbolt_cache.go
@@ -1,0 +1,477 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"net/http"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	"github.com/upbound/xgql/internal/clients"
+)
+
+const (
+	errObjectPut       = "failed to write object"
+	errObjectGet       = "failed to get object"
+	errObjectList      = "failed to list object"
+	errObjectMarshal   = "failed to marshal object"
+	errObjectUnmarshal = "failed to unmarshal object"
+	errObjectZero      = "failed to zero out object"
+	errBucketCreate    = "failed to create bucket"
+	errTxBegin         = "failed to begin transaction"
+	errTxRollback      = "failed to rollback transaction"
+	errFileCreate      = "failed to create db file"
+	errFileClose       = "failed to close db file"
+	errFileRemove      = "failed to remove db file"
+	errDBOpen          = "failed to open db"
+	errCacheCreate     = "failed to create cache"
+	errBucketGet       = "failed to get bucket for object"
+
+	errFmtNoBucket   = "bucket %q does not exist"
+	errFmtObjectGVK  = "failed to get GVK for %+#v"
+	errFmtNoKey      = "key %q does not exist"
+	errFmtObjectType = "unable to convert %+#v to client.Object"
+)
+
+// NewBoltDBFn is a function that creates a new bolt db.
+type NewBoltDBFn func(string) (boltDB, error)
+
+// MarshalFn is a function that marshals an object.
+type MarshalFn func(interface{}) ([]byte, error)
+
+// UnmarshalFn is a function that unmarshals an object.
+type UnmarshalFn func([]byte, interface{}) error
+
+var (
+	DefaultMarshalFn   MarshalFn   = json.Marshal
+	DefaultUnmarshalFn UnmarshalFn = json.Unmarshal
+)
+
+type boltTxCtxKeyType int
+
+var boltTxCtxKey boltTxCtxKeyType
+
+// boltTxCtx is a context value that holds functions to get objects bucket and commit transaction.
+// if boltTxCtxKey is set in context, it will be of this type and will get populated with functions
+// when a transaction is needed for reading.
+type boltTxCtx struct {
+	mu        sync.Mutex
+	used      int
+	getBucket func() (boltBucket, error)
+	done      func() error
+}
+
+// BoltTxMiddleware adds a boltTxCtx to request context.
+func BoltTxMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), boltTxCtxKey, &boltTxCtx{})))
+	})
+}
+
+// WithBBoltCache wraps NewCacheFn with a BBoltCache.
+func WithBBoltCache(file string, opts ...Option) clients.NewCacheMiddlewareFn {
+	return func(fn clients.NewCacheFn) clients.NewCacheFn {
+		return func(cfg *rest.Config, o cache.Options) (cache.Cache, error) {
+			h := fnv.New32()
+			if _, err := h.Write([]byte(cfg.String())); err != nil {
+				return nil, err
+			}
+			// since we can have many clients for different credentials existing concurrently,
+			// and because boltdb cannot be opened for modification concurrently,
+			// add rest.Config hash suffix the the cache file.
+			file = fmt.Sprintf("%s.%d", file, h.Sum32())
+			bc, err := NewBBoltCache(nil, o.Scheme, file, opts...)
+			if err != nil {
+				return nil, err
+			}
+			// set or wrap DefaultTransform.
+			o.DefaultTransform = wrapCacheTranform(o.DefaultTransform, bc.putObject)
+			// get undelying object from cache without copying.
+			o.UnsafeDisableDeepCopy = pointer.Bool(true)
+			// deep copy objects before returning by default.
+			bc.deepCopy = o.UnsafeDisableDeepCopy == nil || !*o.UnsafeDisableDeepCopy
+			ca, err := fn(cfg, o)
+			if err != nil {
+				return nil, err
+			}
+			bc.Cache = ca
+			return bc, nil
+		}
+	}
+}
+
+// wrapCacheTranform returns next if prev is null or creates a new toolscache.TransformFunc
+// that will call both prev and next sequentially.
+func wrapCacheTranform(prev, next toolscache.TransformFunc) toolscache.TransformFunc {
+	if prev == nil {
+		return next
+	}
+	return func(i interface{}) (interface{}, error) {
+		i, err := next(i)
+		if err != nil {
+			return nil, err
+		}
+		return prev(i)
+	}
+}
+
+// Option is an option for a cache.
+type Option func(*BBoltCache)
+
+// Cache implements cache.Cache.
+var _ cache.Cache = &BBoltCache{}
+
+// BBoltCache is a wrapper around a cache.Cache
+// that periodically persists objects to disk and zeroes them out in memory.
+type BBoltCache struct {
+	cache.Cache
+	scheme *runtime.Scheme
+	db     boltDB
+	file   string
+	bucket []byte
+
+	// defaults to true unless cache was created with UnsafeDisableDeepCopy.
+	deepCopy bool
+
+	cleaner Cleaner[client.Object]
+
+	marshalFn   MarshalFn
+	unmarshalFn UnmarshalFn
+
+	running atomic.Bool
+}
+
+// NewBBoltCache creates a new cache.
+func NewBBoltCache(cache cache.Cache, scheme *runtime.Scheme, file string, opts ...Option) (*BBoltCache, error) {
+	ca := &BBoltCache{
+		Cache:       cache,
+		file:        file,
+		bucket:      []byte("objects"),
+		scheme:      scheme,
+		marshalFn:   DefaultMarshalFn,
+		unmarshalFn: DefaultUnmarshalFn,
+	}
+	for _, opt := range opts {
+		opt(ca)
+	}
+	if ca.db == nil {
+		db, err := newBoltDB(ca.file)
+		if err != nil {
+			return nil, errors.Wrap(err, errDBOpen)
+		}
+		ca.db = db
+	}
+	if ca.cleaner == nil {
+		ca.cleaner = NewCleaner[client.Object, string](getKey, ca.cleanup)
+	}
+	return ca, nil
+}
+
+// cleanup is called by cleaner when objects expire. they will be then
+// stored in the "objects" bucket in boltdb and zeroed out in memory.
+func (c *BBoltCache) cleanup(objects []client.Object) error {
+	// sort by key for better transaction performance
+	// https://github.com/etcd-io/bbolt#caveats--limitations.
+	sort.Slice(objects, func(i, j int) bool {
+		return getKey(objects[i]) < getKey(objects[j])
+	})
+	// write objects to the bucket and zero them out in memory.
+	return c.db.Update(func(tx boltTx) error {
+		b, err := tx.CreateBucketIfNotExists(c.bucket)
+		if err != nil {
+			return errors.Wrap(err, errBucketCreate)
+		}
+		for i := range objects {
+			k := []byte(getKey(objects[i]))
+			v, err := c.marshalFn(objects[i])
+			if err != nil {
+				return errors.Wrap(err, errObjectMarshal)
+			}
+			if err := b.Put(k, v); err != nil {
+				return errors.Wrap(err, errObjectPut)
+			}
+			if err := setZero(objects[i]); err != nil {
+				return errors.Wrap(err, errObjectZero)
+			}
+		}
+		return nil
+	})
+}
+
+// getGVK returns schema.GroupVersionKind for a client.Object or client.ObjectList.
+func (c *BBoltCache) getGVK(obj runtime.Object) (schema.GroupVersionKind, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	if _, ok := obj.(client.ObjectList); ok {
+		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+	}
+	return gvk, nil
+}
+
+// Get implements cache.Cache.
+// We delegate to the underlying cache. After retrieving the object, we reschedule its cleanup,
+// re-hydrate its data from the database if empty, and deep copy it before returning.
+func (c *BBoltCache) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	// delegate to the underlying cache, which will start the informers
+	// and begin calling Cache.putObject for each object.
+	if err := c.Cache.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	getBucket, done := c.txOnce(ctx)
+	return errors.Wrap(errors.Join(c.rehydrateObject(obj, c.deepCopy, getBucket), done()), errObjectGet)
+}
+
+// List implements cache.Cache.
+// We find the bucket for storage based on the object's GVK.
+// If we haven't seend this GVK before, we create a new errgroup.Group
+// that will be used to concurrently persist all discovered objects
+// to disk.
+func (c *BBoltCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	// collect list options as we'll use them below to respect deep copy preference.
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+	// delegate to the underlying cache, which will start the informers
+	// and begin calling Cache.putObject for each object.
+	if err := c.Cache.List(ctx, list, &listOpts); err != nil {
+		return err
+	}
+	n := apimeta.LenList(list)
+	// if the list is empty, we're done.
+	if n == 0 {
+		return nil
+	}
+	getBucket, done := c.txOnce(ctx)
+	// deepCopy output object before returning
+	deepCopy := c.deepCopy && (listOpts.UnsafeDisableDeepCopy == nil || !*listOpts.UnsafeDisableDeepCopy)
+	return errors.Wrap(errors.Join(c.rehydrateObjectList(list, deepCopy, getBucket), done()), errObjectList)
+}
+
+// txOnce creates functions to get boltBucket and rollback read-only transaction.
+// if provided context contains a boltTxCtxKey of type *boltTxCtx, then it will be used to
+// get a shared read transaction for the entire request that will be rolled back when the
+// last reader calls done(). otherwise will return functions that will create a unique read
+// transaction.
+func (c *BBoltCache) txOnce(ctx context.Context) (func() (boltBucket, error), func() error) {
+	if bx, ok := ctx.Value(boltTxCtxKey).(*boltTxCtx); ok {
+		bx.mu.Lock()
+		defer bx.mu.Unlock()
+		// each call to txOnce increments the used counter.
+		bx.used++
+		// if we have already set these functions, return them
+		if bx.getBucket != nil {
+			return bx.getBucket, bx.done
+		}
+		var (
+			tx boltTx
+			b  boltBucket
+		)
+		bx.getBucket = func() (boltBucket, error) {
+			bx.mu.Lock()
+			defer bx.mu.Unlock()
+			// we bucket already created, return it.
+			if b != nil {
+				return b, nil
+			}
+			var err error
+			// start a read-only transaction and memoize it in tx.
+			tx, err = c.db.Begin(false)
+			if err != nil {
+				return nil, errors.Wrap(err, errTxBegin)
+			}
+			// retrieve the "objects" bucket and memoize it in b.
+			b = tx.Bucket(c.bucket)
+			return b, nil
+		}
+		bx.done = func() error {
+			bx.mu.Lock()
+			defer bx.mu.Unlock()
+			bx.used--
+			if bx.used > 0 {
+				return nil
+			}
+			if tx == nil {
+				return nil
+			}
+			// we have an active tx and b, and no more users, roll it back and clear.
+			defer func() { tx, b = nil, nil }()
+			return errors.Wrap(tx.Rollback(), errTxRollback)
+		}
+		return bx.getBucket, bx.done
+	}
+	var tx boltTx
+	return sync.OnceValues(func() (boltBucket, error) {
+			var err error
+			tx, err = c.db.Begin(false)
+			if err != nil {
+				return nil, errors.Wrap(err, errTxBegin)
+			}
+			return tx.Bucket(c.bucket), err
+		}),
+		sync.OnceValue(func() error {
+			if tx == nil {
+				return nil
+			}
+			return errors.Wrap(tx.Rollback(), errTxRollback)
+		})
+}
+
+// rehydrateObject reschedules the object for cleanup,
+// and rehydrates it from bolt db bucket if it is currently zeroed out.
+func (c *BBoltCache) rehydrateObject(object client.Object, deepCopy bool, getBucket func() (boltBucket, error)) (rErr error) {
+	// zero out object after duration.
+	c.cleaner.Schedule(object, 1*time.Minute)
+	// deepcopy object before returning.
+	if deepCopy {
+		gvk, err := c.getGVK(object)
+		if err != nil {
+			return errors.Wrapf(err, errFmtObjectGVK, object)
+		}
+		defer func() {
+			if rErr != nil {
+				return
+			}
+			reflect.Indirect(reflect.ValueOf(object)).Set(reflect.Indirect(reflect.ValueOf(object.DeepCopyObject())))
+			object.GetObjectKind().SetGroupVersionKind(gvk)
+		}()
+	}
+	if !isZero(object) {
+		return nil
+	}
+	b, err := getBucket()
+	if err != nil {
+		return err
+	}
+	if b == nil {
+		return errors.Errorf(errFmtNoBucket, c.bucket)
+	}
+	k := getKey(object)
+	v := b.Get([]byte(k))
+	if v == nil {
+		return errors.Errorf(errFmtNoKey, k)
+	}
+	return errors.Wrap(c.unmarshalFn(v, object), errObjectUnmarshal)
+}
+
+// rehydrateObjectList calls rehydrateObject for each object in the list.
+func (c *BBoltCache) rehydrateObjectList(list client.ObjectList, deepCopy bool, getBucket func() (boltBucket, error)) (rErr error) {
+	// here we set up a func to iterate over all objects in the list,
+	// rescheduling clean up and re-hydrating any empty objects from bolt db.
+	rehydrateObject := c.rehydrateObject
+	if deepCopy {
+		// get GVK for deepcopy
+		gvk, err := c.getGVK(list)
+		if err != nil {
+			return errors.Wrapf(err, errFmtObjectGVK, list)
+		}
+		objsCopy := make([]runtime.Object, 0, apimeta.LenList(list))
+		// wrap original rescheduleCleanupAndRehydrateObjectIfZero to copy objects.
+		rehydrateObject = func(object client.Object, _ bool, getBucket func() (boltBucket, error)) error {
+			if err := c.rehydrateObject(object, false, getBucket); err != nil {
+				return err
+			}
+			// create a deep copy.
+			obj := object.DeepCopyObject()
+			obj.GetObjectKind().SetGroupVersionKind(gvk)
+			objsCopy = append(objsCopy, obj)
+			return nil
+		}
+		// replace list with copy.
+		defer func() {
+			if rErr != nil {
+				return
+			}
+			rErr = errors.Wrap(apimeta.SetList(list, objsCopy), errObjectList)
+		}()
+	}
+	return apimeta.EachListItem(list, func(obj runtime.Object) error {
+		object, ok := obj.(client.Object)
+		if !ok {
+			return errors.Errorf(errFmtObjectType, obj)
+		}
+		return rehydrateObject(object, false, getBucket)
+	})
+}
+
+// Start implements cache.Cache.
+// it will close the bolt db when the cache is stopped.
+func (c *BBoltCache) Start(ctx context.Context) (rErr error) {
+	if !c.running.CompareAndSwap(false, true) {
+		return errors.New("already running")
+	}
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		<-ctx.Done()
+		return errors.Join(c.db.Close(), os.Remove(c.file))
+	})
+	g.Go(func() error {
+		return c.cleaner.Start(ctx)
+	})
+	g.Go(func() error {
+		return c.Cache.Start(ctx)
+	})
+	return g.Wait()
+}
+
+// putObject schedules a cleanup for the cached object to reduce memory pressure.
+func (c *BBoltCache) putObject(obj interface{}) (interface{}, error) {
+	if !c.running.Load() {
+		return nil, errors.New("not running")
+	}
+	if object, ok := obj.(client.Object); ok {
+		c.cleaner.Schedule(object, 1*time.Minute)
+	}
+	return obj, nil
+}
+
+// setZero zeros out the supplied object, preserving its namespace and name.
+func setZero(obj client.Object) error {
+	// restore object uid
+	defer obj.SetUID(obj.GetUID())
+	return runtime.SetZeroValue(obj)
+}
+
+// isZero checks if the object has been zeroed out.
+func isZero(obj client.Object) bool {
+	return obj.GetName() == ""
+}
+
+// index objects by their UID.
+func getKey(object client.Object) string {
+	return string(object.GetUID())
+}

--- a/internal/cache/bbolt_cache_test.go
+++ b/internal/cache/bbolt_cache_test.go
@@ -1,0 +1,1028 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"go.etcd.io/bbolt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WithMockBoltDB(db *MockBoltDB) Option {
+	return func(c *BBoltCache) {
+		c.db = db
+	}
+}
+
+func WithMockCache(ca *MockCache) Option {
+	return func(c *BBoltCache) {
+		c.Cache = ca
+	}
+}
+
+func WithMarshalFn(fn MarshalFn) Option {
+	return func(c *BBoltCache) {
+		c.marshalFn = fn
+	}
+}
+
+func WithUnmarshalFn(fn UnmarshalFn) Option {
+	return func(c *BBoltCache) {
+		c.unmarshalFn = fn
+	}
+}
+
+var _ cache.Cache = &MockCache{}
+
+type MockCache struct {
+	MockGet   func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+	MockList  func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+	MockStart func(ctx context.Context) error
+}
+
+// GetInformer implements cache.Cache.
+func (*MockCache) GetInformer(ctx context.Context, obj client.Object) (cache.Informer, error) {
+	panic("unimplemented")
+}
+
+// GetInformerForKind implements cache.Cache.
+func (*MockCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (cache.Informer, error) {
+	panic("unimplemented")
+}
+
+// IndexField implements cache.Cache.
+func (*MockCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	panic("unimplemented")
+}
+
+// Start implements cache.Cache.
+func (m *MockCache) Start(ctx context.Context) error {
+	return m.MockStart(ctx)
+}
+
+// WaitForCacheSync implements cache.Cache.
+func (*MockCache) WaitForCacheSync(ctx context.Context) bool {
+	panic("unimplemented")
+}
+
+func (m *MockCache) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return m.MockGet(ctx, key, obj, opts...)
+}
+
+func (m *MockCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return m.MockList(ctx, list, opts...)
+}
+
+var _ boltDB = &MockBoltDB{}
+
+type MockBoltDB struct {
+	MockBegin  func(writable bool) (boltTx, error)
+	MockView   func(fn func(tx boltTx) error) error
+	MockBatch  func(fn func(tx boltTx) error) error
+	MockUpdate func(fn func(tx boltTx) error) error
+	MockClose  func() error
+}
+
+// Begin implements boltDB.
+func (m *MockBoltDB) Begin(writable bool) (boltTx, error) {
+	return m.MockBegin(writable)
+}
+
+func (m *MockBoltDB) View(fn func(tx boltTx) error) error {
+	return m.MockView(fn)
+}
+
+func (m *MockBoltDB) Batch(fn func(tx boltTx) error) error {
+	return m.MockBatch(fn)
+}
+
+func (m *MockBoltDB) Update(fn func(tx boltTx) error) error {
+	return m.MockUpdate(fn)
+}
+
+func (m *MockBoltDB) Close() error {
+	return m.MockClose()
+}
+
+func (m *MockBoltDB) GetMaxBatchSize() int {
+	return bbolt.DefaultMaxBatchSize
+}
+
+var _ boltTx = &MockBoltTx{}
+
+type MockBoltTx struct {
+	MockCommit                  func() error
+	MockRollback                func() error
+	MockCreateBucketIfNotExists func([]byte) (boltBucket, error)
+	MockBucket                  func([]byte) boltBucket
+}
+
+// Commit implements boltTx.
+func (m *MockBoltTx) Commit() error {
+	return m.MockCommit()
+}
+
+// Rollback implements boltTx.
+func (m *MockBoltTx) Rollback() error {
+	return m.MockRollback()
+}
+
+func (m *MockBoltTx) CreateBucketIfNotExists(bucket []byte) (boltBucket, error) {
+	return m.MockCreateBucketIfNotExists(bucket)
+}
+
+func (m *MockBoltTx) Bucket(bucket []byte) boltBucket {
+	return m.MockBucket(bucket)
+}
+
+var _ boltBucket = &MockBoltBucket{}
+
+type MockBoltBucket struct {
+	MockGet func(key []byte) []byte
+	MockPut func(key, value []byte) error
+}
+
+func (m *MockBoltBucket) Get(key []byte) []byte {
+	return m.MockGet(key)
+}
+
+func (m *MockBoltBucket) Put(key []byte, value []byte) error {
+	return m.MockPut(key, value)
+}
+
+func TestCache_Get(t *testing.T) {
+	errBoom := errors.New("boom")
+	testKind := "ConfigMap"
+	testAPIVersion := "v1"
+	testTypeMeta := metav1.TypeMeta{
+		Kind:       testKind,
+		APIVersion: testAPIVersion,
+	}
+	testName := "test"
+	testNamespace := "test-namespace"
+	testUID := uuid.NewUUID()
+	testObjectMeta := metav1.ObjectMeta{
+		Name:      testName,
+		Namespace: testNamespace,
+		UID:       testUID,
+	}
+	testObjectBytes := []byte(fmt.Sprintf(`{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":%q,"namespace":%q}}`, testName, testNamespace))
+
+	type args struct {
+		key  client.ObjectKey
+		obj  client.Object
+		opts []client.GetOption
+	}
+	type want struct {
+		err error
+		obj client.Object
+	}
+	tests := map[string]struct {
+		reason string
+		cache  cache.Cache
+		opts   []Option
+		before func(*BBoltCache)
+		after  func(*BBoltCache)
+		args   args
+		want   want
+	}{
+		"Success": {
+			reason: "Should get object from bolt cache.",
+			cache: &MockCache{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.ConfigMap); !ok {
+						t.Errorf("\nc.cache.Get(...): want *corev1.ConfigMap, got %+#v", obj)
+					}
+					obj.SetUID(testUID)
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(b bool) (boltTx, error) {
+						if diff := cmp.Diff(false, b); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								if diff := cmp.Diff("objects", string(b)); diff != "" {
+									t.Errorf("\ntx.Bucket(...): -want bucket, +got bucket:\n%s", diff)
+								}
+								return &MockBoltBucket{
+									MockGet: func(k []byte) []byte {
+										if diff := cmp.Diff(string(testUID), string(k)); diff != "" {
+											t.Errorf("\nb.Get(...): -want key, +got key:\n%s", diff)
+										}
+										return testObjectBytes
+									},
+								}
+							},
+							MockRollback: func() error { return nil },
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				obj: &corev1.ConfigMap{},
+				key: client.ObjectKey{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			},
+			want: want{
+				obj: &corev1.ConfigMap{
+					TypeMeta:   testTypeMeta,
+					ObjectMeta: testObjectMeta,
+				},
+			},
+		},
+		"CacheError": {
+			reason: "Should return the error unmodified.",
+			cache: &MockCache{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.ConfigMap); !ok {
+						t.Errorf("\nc.cache.Get(...): want *corev1.ConfigMap, got %+#v", obj)
+					}
+					return errBoom
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{}),
+			},
+			args: args{
+				obj: &corev1.ConfigMap{},
+				key: client.ObjectKey{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			},
+			want: want{
+				err: errBoom,
+				obj: &corev1.ConfigMap{},
+			},
+		},
+		"TxBeginError": {
+			reason: "Should return error if cannot begin read transaction.",
+			cache: &MockCache{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.ConfigMap); !ok {
+						t.Errorf("\nc.cache.Get(...): want *corev1.ConfigMap, got %+#v", obj)
+					}
+					obj.SetUID(testUID)
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(b bool) (boltTx, error) {
+						if diff := cmp.Diff(false, b); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return nil, errBoom
+					},
+				}),
+			},
+			args: args{
+				obj: &corev1.ConfigMap{},
+				key: client.ObjectKey{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			},
+			want: want{
+				obj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: testUID,
+					},
+				},
+				err: errors.Wrap(errors.Wrap(errBoom, errTxBegin), errObjectGet),
+			},
+		},
+		"TxRollbackError": {
+			reason: "Should return error if cannot rollback read transaction.",
+			cache: &MockCache{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.ConfigMap); !ok {
+						t.Errorf("\nc.cache.Get(...): want *corev1.ConfigMap, got %+#v", obj)
+					}
+					obj.SetUID(testUID)
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(b bool) (boltTx, error) {
+						if diff := cmp.Diff(false, b); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								if diff := cmp.Diff("objects", string(b)); diff != "" {
+									t.Errorf("\ntx.Bucket(...): -want bucket, +got bucket:\n%s", diff)
+								}
+								return &MockBoltBucket{
+									MockGet: func(k []byte) []byte {
+										if diff := cmp.Diff(string(testUID), string(k)); diff != "" {
+											t.Errorf("\nb.Get(...): -want key, +got key:\n%s", diff)
+										}
+										return testObjectBytes
+									},
+								}
+							},
+							MockRollback: func() error { return errBoom },
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				obj: &corev1.ConfigMap{},
+				key: client.ObjectKey{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			},
+			want: want{
+				obj: &corev1.ConfigMap{
+					TypeMeta:   testTypeMeta,
+					ObjectMeta: testObjectMeta,
+				},
+				err: errors.Wrap(errors.Wrap(errBoom, errTxRollback), errObjectGet),
+			},
+		},
+		"NoBucket": {
+			reason: "Should return error if bucket does not exist.",
+			cache: &MockCache{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(b bool) (boltTx, error) {
+						if diff := cmp.Diff(false, b); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								return nil
+							},
+							MockRollback: func() error { return nil },
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				obj: &corev1.ConfigMap{},
+				key: client.ObjectKey{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Errorf(errFmtNoBucket, "objects"), errObjectGet),
+				obj: &corev1.ConfigMap{},
+			},
+		},
+		"NoKey": {
+			reason: "Should return error if key does not exist.",
+			cache: &MockCache{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.ConfigMap); !ok {
+						t.Errorf("\nc.cache.Get(...): want *corev1.ConfigMap, got %+#v", obj)
+					}
+					obj.SetUID(testUID)
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(b bool) (boltTx, error) {
+						if diff := cmp.Diff(false, b); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								return &MockBoltBucket{
+									MockGet: func(k []byte) []byte {
+										return nil
+									},
+								}
+							},
+							MockRollback: func() error { return nil },
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				obj: &corev1.ConfigMap{},
+				key: client.ObjectKey{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Errorf(errFmtNoKey, testUID), errObjectGet),
+				obj: &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: testUID,
+					},
+				},
+			},
+		},
+		"UnmarshalError": {
+			reason: "Should return error if object cannot be unmarshalled.",
+			cache: &MockCache{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.ConfigMap); !ok {
+						t.Errorf("\nc.cache.Get(...): want *corev1.ConfigMap, got %+#v", obj)
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(b bool) (boltTx, error) {
+						if diff := cmp.Diff(false, b); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								return &MockBoltBucket{
+									MockGet: func(b []byte) []byte {
+										return []byte("invalid")
+									},
+								}
+							},
+							MockRollback: func() error { return nil },
+						}, nil
+					},
+				}),
+				WithUnmarshalFn(func([]byte, any) error {
+					return errBoom
+				}),
+			},
+			args: args{
+				obj: &corev1.ConfigMap{},
+				key: client.ObjectKey{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.Wrap(errBoom, errObjectUnmarshal), errObjectGet),
+				obj: &corev1.ConfigMap{},
+			},
+		},
+	}
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := NewBBoltCache(tc.cache, scheme.Scheme, "", tc.opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.before != nil {
+				tc.before(c)
+			}
+			err = c.Get(context.TODO(), tc.args.key, tc.args.obj, tc.args.opts...)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nc.Get(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.obj, tc.args.obj); diff != "" {
+				t.Errorf("\n%s\nc.Get(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if tc.after != nil {
+				tc.after(c)
+			}
+		})
+	}
+}
+
+func TestCache_List(t *testing.T) {
+	errBoom := errors.New("boom")
+	testAPIVersion := "v1"
+	testKind := "ConfigMap"
+	testTypeMeta := metav1.TypeMeta{
+		Kind:       testKind,
+		APIVersion: testAPIVersion,
+	}
+	testNamespace := "test-namespace"
+	testNames := []string{"test1", "test2"}
+	testUIDs := []types.UID{uuid.NewUUID(), uuid.NewUUID()}
+	testObjectBytes := make(map[string][]byte, len(testNames))
+	for i := range testNames {
+		testObjectBytes[string(testUIDs[i])] = []byte(fmt.Sprintf(`{"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"%s","namespace":"%s"}}`, testNames[i], testNamespace))
+	}
+	type args struct {
+		list client.ObjectList
+		opts []client.ListOption
+	}
+	type want struct {
+		err  error
+		list client.ObjectList
+	}
+	tests := map[string]struct {
+		reason string
+		cache  cache.Cache
+		opts   []Option
+		before func(*BBoltCache)
+		after  func(*BBoltCache)
+		args   args
+		want   want
+	}{
+		"Success": {
+			reason: "Should successfully list objects from the cache.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					l, ok := list.(*corev1.ConfigMapList)
+					if !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+						return nil
+					}
+					l.Items = []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(writable bool) (boltTx, error) {
+						if diff := cmp.Diff(false, writable); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								if diff := cmp.Diff("objects", string(b)); diff != "" {
+									t.Errorf("\ntx.Bucket(...): -want bucket, +got bucket:\n%s", diff)
+									return nil
+								}
+								return &MockBoltBucket{
+									MockGet: func(b []byte) []byte {
+										return testObjectBytes[string(b)]
+									},
+								}
+							},
+							MockRollback: func() error {
+								return nil
+							},
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				list: &corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						{
+							TypeMeta: testTypeMeta,
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      testNames[0],
+								Namespace: testNamespace,
+								UID:       testUIDs[0],
+							},
+						},
+						{
+							TypeMeta: testTypeMeta,
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      testNames[1],
+								Namespace: testNamespace,
+								UID:       testUIDs[1],
+							},
+						},
+					},
+				},
+			},
+		},
+		"EmptyList": {
+			reason: "Should skip listing objects from cache.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*corev1.ConfigMapList); !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+						return nil
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(bool) (boltTx, error) {
+						t.Errorf("\nc.List(...): should not call tx.Bucket(...)")
+						return nil, errBoom
+					},
+				}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				list: &corev1.ConfigMapList{},
+			},
+		},
+		"CacheError": {
+			reason: "Should return error unmodified.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					_, ok := list.(*corev1.ConfigMapList)
+					if !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+					}
+					return errBoom
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				list: &corev1.ConfigMapList{},
+				err:  errBoom,
+			},
+		},
+		"TxBeginError": {
+			reason: "Should return an error if cannot begin read transactions.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					l, ok := list.(*corev1.ConfigMapList)
+					if !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+						return nil
+					}
+					l.Items = []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(writable bool) (boltTx, error) {
+						if diff := cmp.Diff(false, writable); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return nil, errBoom
+					},
+				}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				err: errors.Wrap(errors.Wrap(errBoom, errTxBegin), errObjectList),
+				list: &corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					},
+				},
+			},
+		},
+		"NoBucket": {
+			reason: "Should return an error if the bucket does not exist.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					l, ok := list.(*corev1.ConfigMapList)
+					if !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+						return nil
+					}
+					l.Items = []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(writable bool) (boltTx, error) {
+						if diff := cmp.Diff(false, writable); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								return nil
+							},
+							MockRollback: func() error {
+								return nil
+							},
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				err: errors.Wrap(errors.Errorf(errFmtNoBucket, "objects"), errObjectList),
+				list: &corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					},
+				},
+			},
+		},
+		"NoKey": {
+			reason: "Should skip if the key does not exist.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					l, ok := list.(*corev1.ConfigMapList)
+					if !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+						return nil
+					}
+					l.Items = []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(writable bool) (boltTx, error) {
+						if diff := cmp.Diff(false, writable); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								return &MockBoltBucket{
+									MockGet: func(b []byte) []byte {
+										return nil
+									},
+								}
+							},
+							MockRollback: func() error {
+								return nil
+							},
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				list: &corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					},
+				},
+				err: errors.Wrap(errors.Errorf(errFmtNoKey, testUIDs[0]), errObjectList),
+			},
+		},
+		"TxRollbackError": {
+			reason: "Should return error if read tx cannot be rolled back.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					l, ok := list.(*corev1.ConfigMapList)
+					if !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+						return nil
+					}
+					l.Items = []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(writable bool) (boltTx, error) {
+						if diff := cmp.Diff(false, writable); diff != "" {
+							t.Errorf("\ndb.Begin(...): -want writable, +got writable:\n%s", diff)
+						}
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								return &MockBoltBucket{
+									MockGet: func(b []byte) []byte {
+										return testObjectBytes[string(b)]
+									},
+								}
+							},
+							MockRollback: func() error {
+								return errBoom
+							},
+						}, nil
+					},
+				}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				list: &corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						{
+							TypeMeta: testTypeMeta,
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      testNames[0],
+								Namespace: testNamespace,
+								UID:       testUIDs[0],
+							},
+						},
+						{
+							TypeMeta: testTypeMeta,
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      testNames[1],
+								Namespace: testNamespace,
+								UID:       testUIDs[1],
+							},
+						},
+					},
+				},
+				err: errors.Wrap(errors.Wrap(errBoom, errTxRollback), errObjectList),
+			},
+		},
+		"UnmarshalError": {
+			reason: "Should return an error if the object cannot be unmarshalled.",
+			cache: &MockCache{
+				MockList: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+					l, ok := list.(*corev1.ConfigMapList)
+					if !ok {
+						t.Errorf("\nc.cache.List(...): want *corev1.ConfigMapList, got %+#v", list)
+						return nil
+					}
+					l.Items = []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					}
+					return nil
+				},
+			},
+			opts: []Option{
+				WithMockBoltDB(&MockBoltDB{
+					MockBegin: func(writable bool) (boltTx, error) {
+						return &MockBoltTx{
+							MockBucket: func(b []byte) boltBucket {
+								return &MockBoltBucket{
+									MockGet: func(b []byte) []byte {
+										return []byte("invalid")
+									},
+								}
+							},
+							MockRollback: func() error {
+								return nil
+							},
+						}, nil
+					},
+				}),
+				WithUnmarshalFn(func([]byte, any) error {
+					return errBoom
+				}),
+			},
+			args: args{
+				list: &corev1.ConfigMapList{},
+			},
+			want: want{
+				err: errors.Wrap(errors.Wrap(errBoom, errObjectUnmarshal), errObjectList),
+				list: &corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[0],
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: testUIDs[1],
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := NewBBoltCache(tc.cache, scheme.Scheme, "", tc.opts...)
+			c.deepCopy = true
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.before != nil {
+				tc.before(c)
+			}
+			err = c.List(context.TODO(), tc.args.list, tc.args.opts...)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nc.List(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.list, tc.args.list); diff != "" {
+				t.Errorf("\n%s\nc.List(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if tc.after != nil {
+				tc.after(c)
+			}
+		})
+	}
+}

--- a/internal/cache/bbolt_wrapper.go
+++ b/internal/cache/bbolt_wrapper.go
@@ -1,0 +1,125 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import bolt "go.etcd.io/bbolt"
+
+// newBoltDB creates a new bolt db.
+func newBoltDB(file string) (boltDB, error) {
+	db, err := bolt.Open(file, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+	db.NoSync = true
+	db.NoFreelistSync = true
+	db.FreelistType = bolt.FreelistMapType
+	return (*wdb)(db), nil
+}
+
+// unwrapDBFn is a helper to transform func(boltTx) error into
+// func(*bbolt.Tx) error.
+func unwrapDBFn(fn func(boltTx) error) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return fn((*wtx)(tx))
+	}
+}
+
+var _ boltDB = &wdb{}
+
+type wdb bolt.DB
+
+// Begin implements boltDB.
+func (w *wdb) Begin(writable bool) (boltTx, error) {
+	tx, err := (*bolt.DB)(w).Begin(writable)
+	if err != nil {
+		return nil, err
+	}
+	return (*wtx)(tx), nil
+}
+
+// View implements boltDB.
+func (w *wdb) View(fn func(boltTx) error) error {
+	return (*bolt.DB)(w).View(unwrapDBFn(fn))
+}
+
+// Batch implements boltDB.
+func (w *wdb) Batch(fn func(boltTx) error) error {
+	return (*bolt.DB)(w).Batch(unwrapDBFn(fn))
+}
+
+// Update implements boltDB.
+func (w *wdb) Update(fn func(boltTx) error) error {
+	return (*bolt.DB)(w).Update(unwrapDBFn(fn))
+}
+
+// Close implements boltDB.
+func (w *wdb) Close() error {
+	return (*bolt.DB)(w).Close()
+}
+
+var _ boltTx = &wtx{}
+
+type wtx bolt.Tx
+
+// Commit implements boltTx.
+func (w *wtx) Commit() error {
+	return (*bolt.Tx)(w).Commit()
+}
+
+// Rollback implements boltTx.
+func (w *wtx) Rollback() error {
+	return (*bolt.Tx)(w).Rollback()
+}
+
+// Bucket implements boltTx.
+func (w *wtx) Bucket(name []byte) boltBucket {
+	b := (*bolt.Tx)(w).Bucket(name)
+	if b == nil {
+		return nil
+	}
+	return b
+}
+
+// CreateBucketIfNotExists implements boltTx.
+func (w *wtx) CreateBucketIfNotExists(name []byte) (boltBucket, error) {
+	b, err := (*bolt.Tx)(w).CreateBucketIfNotExists(name)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// boltDB wraps bbolt.DB
+type boltDB interface {
+	Begin(writable bool) (boltTx, error)
+	View(func(boltTx) error) error
+	Batch(func(boltTx) error) error
+	Update(func(boltTx) error) error
+	Close() error
+}
+
+// boltTx wraps bbolt.Tx
+type boltTx interface {
+	Commit() error
+	Rollback() error
+	Bucket([]byte) boltBucket
+	CreateBucketIfNotExists([]byte) (boltBucket, error)
+}
+
+// boltBucket wraps bbolt.Bucket
+type boltBucket interface {
+	Get(key []byte) []byte
+	Put(key []byte, value []byte) error
+}

--- a/internal/cache/cleaner.go
+++ b/internal/cache/cleaner.go
@@ -1,0 +1,223 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// Cleaner cleans up objects after a given duration.
+type Cleaner[T any] interface {
+	// Schedule adds obj to clean in exp interval.
+	Schedule(obj T, exp time.Duration)
+	// Start runs until context is done.
+	Start(context.Context) error
+}
+
+var _ Cleaner[any] = (*cleaner[any, int])(nil)
+
+// expKey is object expiry entry, it is going to be cleaned
+// when its at timestamp older than current timestamp.
+// before cleaning, its gen generation is compared to
+// the generation of the ref with the matching key, if
+// generations match, the ref is removed and object will
+// be cleaned.
+type expKey[K cmp.Ordered] struct {
+	gen uint64
+	key K
+	at  time.Time
+}
+
+// expRef is an object reference entry. when an expiry key
+// reaches its expiration timestamp, its generation is compared
+// to the reference's generation, if they match, the reference
+// gets cleaned.
+type expRef[T any] struct {
+	gen uint64
+	obj T
+}
+
+// cleaner implements Cleaner.
+// executes provided cleanFn for all objects that have
+// expired at a given time.
+// uses keyFn for deduplicating and keeping object references.
+// all scheduled cleanups are kept in exps slice ordered by
+// at time.Time.
+// all objects are help in refs map indexed by key generated
+// using provided keyFn.
+// When an object is Schedule'd for cleanup, a new expKey
+// entry is added to the exps slice at an index determined
+// by the at time. The scheduled object is added to the refs
+// map and its gen is incremented. The new value of gen is
+// stored with the expKey entry.
+// When clock reaches the expiration time of one of the
+// scheduled objects, its expKey gen is compared with the
+// expRef entry is the refs map, object is going to be cleaned
+// up using the cleanFn if values of gen match. This allows
+// scheduling object repeatedly without modifying existing
+// exps entries and only the last schedule being respected.
+// there is a potential for an unexpected cleanup if a previously
+// scheduled object is rescheduled at a lower time and then again
+// at a higher time, leaving a conflicting dangling expKey that
+// should be ignored. To fix this, we can add a cleaner level
+// gen counter, but since we're only scheduling cleanups at a
+// constant interval, this is not needed.
+type cleaner[T any, K cmp.Ordered] struct {
+	keyFn   func(T) K
+	cleanFn func([]T) error
+
+	clock   clock.Clock
+	signal  chan struct{}
+	running atomic.Bool
+	mu      sync.Mutex
+	exps    []expKey[K]
+	refs    map[K]expRef[T]
+}
+
+type CleanerOpt[T any, K cmp.Ordered] func(*cleaner[T, K])
+
+// NewCleaner creates a cleaner for objects of type T, identified by comparable key K,
+// using cleanFn for cleanup.
+func NewCleaner[T any, K cmp.Ordered](keyFn func(T) K, cleanFn func([]T) error, opts ...CleanerOpt[T, K]) *cleaner[T, K] {
+	c := &cleaner[T, K]{
+		keyFn:   keyFn,
+		cleanFn: cleanFn,
+		clock:   clock.RealClock{},
+		signal:  make(chan struct{}),
+		refs:    make(map[K]expRef[T]),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Schedule implements Cleaner.
+func (c *cleaner[T, K]) Schedule(obj T, exp time.Duration) {
+	if exp < 0 {
+		panic("negative expiration")
+	}
+	if c.add(obj, c.clock.Now().Add(exp)) {
+		select {
+		case c.signal <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// Start implements Cleaner.
+func (c *cleaner[T, K]) Start(ctx context.Context) error {
+	if !c.running.CompareAndSwap(false, true) {
+		return errors.New("already running")
+	}
+	defer c.running.Store(false)
+	var wakeup <-chan time.Time
+	for {
+		select {
+		case <-wakeup:
+			wakeup = nil
+		case <-c.signal:
+		case <-ctx.Done():
+			return nil
+		}
+		objs, exp := c.collect(c.clock.Now())
+		if len(objs) > 0 {
+			if err := c.cleanFn(objs); err != nil {
+				return err
+			}
+		}
+		if !exp.IsZero() {
+			wakeup = c.clock.After(exp.Sub(c.clock.Now()))
+		}
+	}
+}
+
+// add adds a expKey to the exps slices and a expRef to the refs map.
+// if new expKey is added at the beginning of the slice because its
+// expiration is sooner than any existing entries, add returns true.
+// This is used to signal the select in the cleanup goroutine loop
+// to re-set the wakeup timer.
+func (c *cleaner[T, K]) add(obj T, at time.Time) bool {
+	// generate object's key using the provided keyFn.
+	k := c.keyFn(obj)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// determine if this is going to be the first key to expire.
+	newest := len(c.exps) == 0 || c.exps[0].at.After(at)
+	// find the index for insertion ordered by expiration time.
+	// when a key at the same expiration time exists, order by key.
+	i := sort.Search(len(c.exps), func(i int) bool {
+		if c.exps[i].at.Equal(at) {
+			return c.exps[i].key >= k
+		}
+		return c.exps[i].at.After(at)
+	})
+	// key already exists at expiration, skip it.
+	if i < len(c.exps) && c.exps[i].key == k && c.exps[i].at.Equal(at) {
+		return false
+	}
+	// store key and increment generation, this will void previously
+	// scheduled expirations for this object.
+	g := c.refs[k]
+	g.obj = obj
+	g.gen++
+	c.refs[k] = g
+	// insert expKey at index.
+	if i < len(c.exps) {
+		// glow exps slice.
+		c.exps = append(c.exps[:i+1], c.exps[i:]...)
+		// set expKey.
+		c.exps[i].gen = g.gen
+		c.exps[i].key = k
+		c.exps[i].at = at
+		// re-schedule cleaning if our shortest expiration changed
+		return newest
+	}
+	// append expKey generation.
+	c.exps = append(c.exps, expKey[K]{gen: g.gen, key: k, at: at})
+	return newest
+}
+
+// collect drops all expired expKeys from exps slice and returns all
+// valid objects for cleanup. object is valid for cleanup if its expKey
+// gen matches is expRef gen.
+func (c *cleaner[T, K]) collect(now time.Time) (objs []T, exp time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for {
+		if len(c.exps) == 0 {
+			return
+		}
+		if c.exps[0].at.After(now) {
+			exp = c.exps[0].at
+			return
+		}
+		k := c.exps[0].key
+		g := c.exps[0].gen
+		if gen, ok := c.refs[k]; ok && gen.gen == g {
+			delete(c.refs, k)
+			objs = append(objs, gen.obj)
+		}
+		c.exps = c.exps[1:]
+	}
+}

--- a/internal/cache/cleaner_test.go
+++ b/internal/cache/cleaner_test.go
@@ -1,0 +1,183 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/clock"
+	ktesting "k8s.io/utils/clock/testing"
+)
+
+func TestCleaner_Schedule(t *testing.T) {
+	t.Parallel()
+	type cleanup struct {
+		At    time.Duration
+		Items []int
+	}
+	type want struct {
+		cleanups []cleanup
+	}
+	type step func(clock *ktesting.FakeClock, cleaner *cleaner[int, int])
+
+	schedule := func(item int, exp time.Duration) step {
+		return func(_ *ktesting.FakeClock, cleaner *cleaner[int, int]) {
+			cleaner.Schedule(item, exp)
+		}
+	}
+	sleep := func(duration time.Duration) step {
+		return func(clock *ktesting.FakeClock, _ *cleaner[int, int]) {
+			clock.Sleep(duration)
+			runtime.Gosched()
+		}
+	}
+
+	tests := map[string]struct {
+		reason string
+		steps  []step
+		want   want
+	}{
+		"Success": {
+			steps: []step{
+				schedule(1, 1*time.Millisecond),
+				schedule(1, 1*time.Millisecond),
+				schedule(1, 1*time.Millisecond),
+				schedule(1, 1*time.Millisecond),
+				sleep(1 * time.Millisecond),
+			},
+			want: want{
+				cleanups: []cleanup{
+					{At: 1 * time.Millisecond, Items: []int{1}},
+				},
+			},
+		},
+		"Reschedules": {
+			steps: []step{
+				schedule(1, 2*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				schedule(1, 2*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				schedule(1, 2*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				schedule(1, 2*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				sleep(1 * time.Millisecond),
+			},
+			want: want{
+				cleanups: []cleanup{
+					{At: 5 * time.Millisecond, Items: []int{1}},
+				},
+			},
+		},
+		"Batches": {
+			steps: []step{
+				schedule(1, 1*time.Millisecond),
+				schedule(2, 1*time.Millisecond),
+				schedule(3, 1*time.Millisecond),
+				schedule(4, 1*time.Millisecond),
+				sleep(1 * time.Millisecond),
+			},
+			want: want{
+				cleanups: []cleanup{
+					{At: 1 * time.Millisecond, Items: []int{1, 2, 3, 4}},
+				},
+			},
+		},
+		"Reorders": {
+			steps: []step{
+				schedule(1, 5*time.Millisecond),
+				schedule(2, 5*time.Millisecond),
+				schedule(3, 5*time.Millisecond),
+				schedule(4, 5*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				schedule(4, 1*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				schedule(3, 1*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				schedule(2, 1*time.Millisecond),
+				sleep(1 * time.Millisecond),
+				sleep(1 * time.Millisecond),
+			},
+			want: want{
+				cleanups: []cleanup{
+					{At: 2 * time.Millisecond, Items: []int{4}},
+					{At: 3 * time.Millisecond, Items: []int{3}},
+					{At: 4 * time.Millisecond, Items: []int{2}},
+					{At: 5 * time.Millisecond, Items: []int{1}},
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			now := time.Now()
+			clock := ktesting.NewFakeClock(now)
+			cleanupsCh := make(chan cleanup)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			cleaner := NewCleaner(
+				func(i int) int { return i },
+				func(i []int) error {
+					cleanupsCh <- cleanup{Items: i, At: clock.Now().Sub(now)}
+					return nil
+				},
+				WithClock(clock),
+			)
+			startedCh := make(chan struct{})
+			errCh := make(chan error, 1)
+			go func() {
+				close(startedCh)
+				defer close(cleanupsCh)
+				errCh <- cleaner.Start(ctx)
+			}()
+			go func() {
+				<-startedCh
+				for _, step := range tc.steps {
+					step(clock, cleaner)
+				}
+			}()
+			var cleanups []cleanup
+			for cleanup := range cleanupsCh {
+				cleanups = append(cleanups, cleanup)
+				if !clock.HasWaiters() {
+					break
+				}
+			}
+			cancel()
+			if diff := cmp.Diff(nil, <-errCh); diff != "" {
+				t.Errorf("Start(...): -want err, +got err:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.cleanups, cleanups); diff != "" {
+				t.Errorf("Schedule(...): -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff([]expKey[int]{}, cleaner.exps); diff != "" {
+				t.Errorf("Expiration Queue: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(map[int]expRef[int]{}, cleaner.refs); diff != "" {
+				t.Errorf("Expiration References: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func WithClock(clock clock.Clock) CleanerOpt[int, int] {
+	return func(c *cleaner[int, int]) {
+		c.clock = clock
+	}
+}

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -220,11 +220,6 @@ type GetOption func(o *getOptions)
 
 // Get a client that uses the specified bearer token.
 func (c *Cache) Get(cr auth.Credentials, o ...GetOption) (client.Client, error) { //nolint:gocyclo
-	opts := &getOptions{}
-	for _, fn := range o {
-		fn(opts)
-	}
-
 	extra := bytes.Buffer{}
 	extra.Write(c.salt)
 	id := cr.Hash(extra.Bytes())

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -116,6 +116,7 @@ func Anonymize(cfg *rest.Config) *rest.Config {
 // type the client is asked to get or list. Clients (and their caches) expire
 // and are garbage collected if they are unused for five minutes.
 type Cache struct {
+	// a context that will be valid for the lifetime of Cache.
 	ctx    context.Context
 	active map[string]*session
 	mx     sync.RWMutex
@@ -248,13 +249,11 @@ func (c *Cache) Get(cr auth.Credentials, o ...GetOption) (client.Client, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, errNewHTTPClient)
 	}
-
-	caopt := cache.Options{
+	ca, err := c.newCache(cfg, cache.Options{
 		HTTPClient: hc,
 		Scheme:     c.scheme,
 		Mapper:     c.mapper,
-	}
-	ca, err := c.newCache(cfg, caopt)
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, errNewCache)
 	}

--- a/internal/graph/resolvers/apiextensions.go
+++ b/internal/graph/resolvers/apiextensions.go
@@ -30,7 +30,6 @@ import (
 	extv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 
 	"github.com/upbound/xgql/internal/auth"
-	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/model"
 	"github.com/upbound/xgql/internal/unstructured"
 )
@@ -164,15 +163,13 @@ func (r *xrd) DefinedCompositeResourceClaims(ctx context.Context, obj *model.Com
 
 	options.DeprecationPatch(version, namespace)
 
-	gopts := []clients.GetOption{}
 	lopts := []client.ListOption{}
 	if options.Namespace != nil {
-		gopts = []clients.GetOption{clients.ForNamespace(*options.Namespace)}
 		lopts = []client.ListOption{client.InNamespace(*options.Namespace)}
 	}
 
 	creds, _ := auth.FromContext(ctx)
-	c, err := r.clients.Get(creds, gopts...)
+	c, err := r.clients.Get(creds)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))
 		return model.CompositeResourceClaimConnection{}, nil

--- a/internal/graph/resolvers/query.go
+++ b/internal/graph/resolvers/query.go
@@ -32,7 +32,6 @@ import (
 	pkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 
 	"github.com/upbound/xgql/internal/auth"
-	"github.com/upbound/xgql/internal/clients"
 	"github.com/upbound/xgql/internal/graph/model"
 	xunstructured "github.com/upbound/xgql/internal/unstructured"
 )
@@ -161,15 +160,13 @@ func (r *query) KubernetesResources(ctx context.Context, apiVersion, kind string
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	gopts := []clients.GetOption{}
 	lopts := []client.ListOption{}
 	if namespace != nil {
-		gopts = []clients.GetOption{clients.ForNamespace(*namespace)}
 		lopts = []client.ListOption{client.InNamespace(*namespace)}
 	}
 
 	creds, _ := auth.FromContext(ctx)
-	c, err := r.clients.Get(creds, gopts...)
+	c, err := r.clients.Get(creds)
 	if err != nil {
 		graphql.AddError(ctx, errors.Wrap(err, errGetClient))
 		return model.KubernetesResourceConnection{}, nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

- Update dependency versions.
- Added a new cache wrapper that:
  - Stores full objects in a bolt database on disk.
  - Clears object fields using a cache.TransformFunc.
  - Enriches objects with data from disk before returning.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Launched this patched version on an MCP and verified results.
