### PR TITLE
skip websocket auth init if initialized

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -143,6 +143,13 @@ func Middleware(next http.Handler) http.Handler {
 }
 
 func WebsocketInit(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
+	// don't re-initialize credentials from the init payload if present in request headers.
+	if cr, ok := FromContext(ctx); ok {
+		if cr.BasicUsername != "" || cr.BasicPassword != "" || cr.BearerToken != "" ||
+			cr.Impersonate.Username != "" || len(cr.Impersonate.Groups) > 0 || len(cr.Impersonate.Extra) > 0 {
+			return ctx, nil
+		}
+	}
 	r := &http.Request{
 		Header: make(http.Header),
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

During websocket initialization we overwrote auth context populated from the
request middleware. This is necessary when using the playground as browsers
send only a limited subset of headers when initializing a websocket connection.
However, for programmatic websocket clients that do send auth headers in the
initial upgrade request, the websocket init function was clearing those from
context.

This PR makes auth context initialization from the websocket connection init
function conditional and only runs if auth context wasn't already initialized.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
I'm testing this locally with a programmatic websocket client.
