### PR TITLE
Turn --debug into a counter and set klog verbosity to its value

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -231,7 +231,7 @@ func (c *Cache) Get(cr auth.Credentials, o ...GetOption) (client.Client, error) 
 	c.mx.RUnlock()
 
 	if ok {
-		log.Debug("Used existing client",
+		log.Debug("Used existing cached client",
 			"new-expiry", time.Now().Add(c.expiry),
 		)
 		sn.expiration.Reset(c.expiry)
@@ -284,7 +284,7 @@ func (c *Cache) Get(cr auth.Credentials, o ...GetOption) (client.Client, error) 
 	// another gorouting might have set the session.
 	if sn, ok := c.active[id]; ok {
 		c.mx.Unlock()
-		log.Debug("Used existing client",
+		log.Debug("Used existing cached client",
 			"duration", time.Since(started),
 			"new-expiry", newExpiry,
 		)
@@ -321,7 +321,7 @@ func (c *Cache) Get(cr auth.Credentials, o ...GetOption) (client.Client, error) 
 		return nil, errors.New(errWaitForCacheSync)
 	}
 
-	log.Debug("Created client",
+	log.Debug("Created cached client",
 		"duration", time.Since(started),
 		"new-expiry", newExpiry,
 	)


### PR DESCRIPTION
With `-d -d -d -d -d -d` client-go logs requests. So one can actually see what xgql is doing behind the scenes and why requests take long.

Tested locally:

<img width="1728" alt="Bildschirmfoto 2023-11-21 um 13 53 15" src="https://github.com/upbound/xgql/assets/730123/315d3d89-141a-48fd-9d5e-788ed236aca1">

