### PR TITLE
bbolt-cache: debug log when cleaning objects, and throttle to once per 1s

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -216,7 +216,7 @@ func main() { //nolint:gocyclo
 	var camid []clients.NewCacheMiddlewareFn
 	// wrap client.Cache in cache.*BBoltCache if cacheFile is specified.
 	if *cacheFile != "" {
-		camid = append(camid, cache.WithBBoltCache(*cacheFile))
+		camid = append(camid, cache.WithBBoltCache(*cacheFile, cache.WithLogger(log)))
 	}
 	// enable live queries
 	camid = append(camid, clients.WithLiveQueries)

--- a/internal/cache/cleaner_test.go
+++ b/internal/cache/cleaner_test.go
@@ -138,6 +138,7 @@ func TestCleaner_Schedule(t *testing.T) {
 					return nil
 				},
 				WithClock(clock),
+				WithTick[int, int](time.Duration(0)),
 			)
 			startedCh := make(chan struct{})
 			errCh := make(chan error, 1)


### PR DESCRIPTION
We are continously cleaning objects it seems. In `upbound/sttts-2000-claims` roughly 25-30 per second, despite no requests.

This PR makes that visible.

Test locally by running with the playground again upper controlplane.