### PR TITLE
Fix excess memory consumption

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -119,7 +119,7 @@ func main() { //nolint:gocyclo
 		agent           = app.Flag("trace-agent", "Address of the Jaeger trace agent as [host]:[port]").TCP()
 		health          = app.Flag("health", "Enable health endpoints.").Default("true").Bool()
 		healthPort      = app.Flag("health-port", "Port used for readyz and livez requests.").Default("8088").Int()
-		cacheExpiry     = app.Flag("cache-expiry", "The duration since last activity by a user until that users client expires.").Default("336h").Duration()
+		cacheExpiry     = app.Flag("cache-expiry", "The duration since last activity by a user until that users client expires.").Default("30m").Duration()
 		profiling       = app.Flag("profiling", "Enable profiling via web interface host:port/debug/pprof/.").Default("true").Bool()
 		cacheFile       = app.Flag("cache-file", "Path to the file used to persist client caches, set to reduce memory usage.").Default("").String()
 		noApolloTracing = app.Flag("disable-apollo-tracing", "Disable apollo tracing.").Bool()

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -92,14 +92,14 @@ func TestCredentialsHash(t *testing.T) {
 					Extra:    map[string][]string{"coolness": {"very"}},
 				},
 			},
-			want: "3a891076971c12916e6e52149563cba9b165017460c3fb7164f07f5bb5d94f18",
+			want: "077ae566a720ee75c24fe72441962d258909a380d0f1bf9da576e88ca8f871cd",
 		},
 		"Extra": {
 			creds: Credentials{
 				BearerToken: "toke-one",
 			},
 			extra: []byte("coolness"),
-			want:  "3a9957abe9a6091449e9a1facbde080fe01a291f62e88f9276a4d39d18be8393",
+			want:  "2d0c7f73540de525665793bb7a8c970ecaaf4c8f9a08920327819803648e4006",
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes
- make hash generation for client-id deterministic
- remove bearertoken as that is regenerated every 90s

This fixes a problem we were seeing where the same requester was identified as different clients resulting in excess informer cache accumulation and unbounded heap growth.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Deployed the changes out to some Upbound control planes and verified (through logging) that the client cache remained small and that memory and cpu did not grow unbounded (via metrics).