### PR TITLE
Add support for authenticating proxy

### DIFF
--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"io"
@@ -110,6 +112,7 @@ func main() { //nolint:gocyclo
 		app             = kingpin.New(filepath.Base(os.Args[0]), "A GraphQL API for Crossplane.").DefaultEnvars()
 		debug           = app.Flag("debug", "Enable debug logging.").Short('d').Counter()
 		listen          = app.Flag("listen", "Address at which to listen for TLS connections. Requires TLS cert and key.").Default(":8443").String()
+		clientCABundle  = app.Flag("client-ca-bundle", "Path to the CA bundle that will be used to verify a client's certificate if the client sends a certificate during the TLS handshake.").ExistingFile()
 		tlsCert         = app.Flag("tls-cert", "Path to the TLS certificate file used to serve TLS connections.").ExistingFile()
 		tlsKey          = app.Flag("tls-key", "Path to the TLS key file used to serve TLS connections.").ExistingFile()
 		tlsClientCert   = app.Flag("tls-client-cert", "Path to the TLS client certificate file used for API server connections.").ExistingFile()
@@ -310,6 +313,17 @@ func main() { //nolint:gocyclo
 			ReadHeaderTimeout: 5 * time.Second,
 			ErrorLog:          stdlog.New(io.Discard, "", 0),
 		}
+		if len(*clientCABundle) > 0 {
+			p, err := getCertPool(*clientCABundle)
+			if err != nil {
+				kingpin.FatalIfError(err, "cannot initialize the client CA pool from the specified bundle %s", *clientCABundle)
+			}
+			srv.TLSConfig = &tls.Config{
+				ClientAuth: tls.VerifyClientCertIfGiven,
+				ClientCAs:  p,
+				MinVersion: tls.VersionTLS12,
+			}
+		}
 		go func() {
 			log.Debug("Listening for TLS connections", "address", *listen)
 			kingpin.FatalIfError(srv.ListenAndServeTLS(*tlsCert, *tlsKey), "cannot serve TLS HTTP")
@@ -326,6 +340,19 @@ func main() { //nolint:gocyclo
 		ErrorLog:          stdlog.New(io.Discard, "", 0),
 	}
 	kingpin.FatalIfError(srv.ListenAndServe(), "cannot serve insecure HTTP")
+}
+
+// getCertPool parses the provided CA bundle file and returns a CertPool.
+func getCertPool(caBundle string) (*x509.CertPool, error) {
+	result := x509.NewCertPool()
+	ca, err := os.ReadFile(filepath.Clean(caBundle))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read CA bundle file")
+	}
+	if !result.AppendCertsFromPEM(ca) {
+		return nil, errors.New("failed to append CA certificate to pool")
+	}
+	return result, nil
 }
 
 // startHealth starts the readyz and livez endpoints for this service.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -41,12 +41,23 @@ const (
 	headerImpersonateUser        = "Impersonate-User"
 	headerImpersonateGroup       = "Impersonate-Group"
 	headerPrefixImpersonateExtra = "Impersonate-Extra-"
+	headerXRemoteUser            = "X-Remote-User"
+	headerXRemoteGroup           = "X-Remote-Group"
+	headerPrefixXRemoteExtra     = "X-Remote-Extra-"
 )
 
 // Impersonation specifies a subject to impersonate. Impersonation configuration
-// does not consistute credentials; it must be supplied alongside credentials
+// does not constitute credentials; it must be supplied alongside credentials
 // for a subject that has been granted RBAC access to impersonate.
 type Impersonation struct {
+	Username string
+	Groups   []string
+	Extra    map[string][]string
+}
+
+// AuthenticatingProxy represents the user information from the HTTP headers set
+// by an authentication proxy in front of xgql.
+type AuthenticatingProxy struct {
 	Username string
 	Groups   []string
 	Extra    map[string][]string
@@ -55,10 +66,11 @@ type Impersonation struct {
 // Credentials that a caller may pass to xgql in order to authenticate to a
 // Kubernetes API server.
 type Credentials struct {
-	BearerToken   string
-	BasicUsername string
-	BasicPassword string
-	Impersonate   Impersonation
+	BearerToken         string
+	BasicUsername       string
+	BasicPassword       string
+	Impersonate         Impersonation
+	AuthenticatingProxy AuthenticatingProxy
 }
 
 // Inject returns a copy of the supplied REST config with credentials injected.
@@ -72,7 +84,44 @@ func (c Credentials) Inject(cfg *rest.Config) *rest.Config {
 		Groups:   c.Impersonate.Groups,
 		Extra:    c.Impersonate.Extra,
 	}
+
+	// Add authenticating proxy headers if configured
+	if c.AuthenticatingProxy.Username != "" || len(c.AuthenticatingProxy.Groups) > 0 || len(c.AuthenticatingProxy.Extra) > 0 {
+		out.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			return &authenticatingProxyTransport{
+				RoundTripper: rt,
+				username:     c.AuthenticatingProxy.Username,
+				groups:       c.AuthenticatingProxy.Groups,
+				extra:        c.AuthenticatingProxy.Extra,
+			}
+		})
+	}
+
 	return out
+}
+
+// authenticatingProxyTransport is a round tripper that
+// adds X-Remote-* headers to requests.
+type authenticatingProxyTransport struct {
+	http.RoundTripper
+	username string
+	groups   []string
+	extra    map[string][]string
+}
+
+func (t *authenticatingProxyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.username != "" {
+		req.Header.Set(headerXRemoteUser, t.username)
+	}
+	for _, group := range t.groups {
+		req.Header.Add(headerXRemoteGroup, group)
+	}
+	for k, v := range t.extra {
+		for _, val := range v {
+			req.Header.Add(headerPrefixXRemoteExtra+k, val)
+		}
+	}
+	return t.RoundTripper.RoundTrip(req)
 }
 
 // Hash returns a SHA-256 hash of the supplied credentials, plus any extra bytes
@@ -84,10 +133,12 @@ func (c Credentials) Hash(extra []byte) string {
 	// set of groups.
 	gset := sets.New[string]()
 	gset.Insert(c.Impersonate.Groups...)
+	gset.Insert(c.AuthenticatingProxy.Groups...)
 	sortedGroups := sets.List(gset)
 
 	h := sha256.New()
 	h.Write([]byte(c.Impersonate.Username))
+	h.Write([]byte(c.AuthenticatingProxy.Username))
 	for _, g := range sortedGroups {
 		h.Write([]byte(g))
 	}
@@ -126,16 +177,39 @@ func ExtractImpersonation(r *http.Request) Impersonation {
 	return i
 }
 
+// ExtractAuthenticatingProxy extracts the user info from the HTTP headers set
+// by an authenticating proxy (if any).
+func ExtractAuthenticatingProxy(r *http.Request) AuthenticatingProxy {
+	extra := make(map[string][]string)
+	for k, v := range r.Header {
+		if !strings.HasPrefix(k, headerPrefixXRemoteExtra) {
+			continue
+		}
+		extra[strings.TrimPrefix(k, headerPrefixXRemoteExtra)] = v
+	}
+
+	ap := AuthenticatingProxy{
+		Username: r.Header.Get(headerXRemoteUser),
+		Groups:   r.Header.Values(headerXRemoteGroup),
+	}
+	if len(extra) > 0 {
+		ap.Extra = extra
+	}
+
+	return ap
+}
+
 // Middleware extracts credentials from the HTTP request and stashes them in its
 // context.
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bu, bp, _ := r.BasicAuth()
 		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), key, Credentials{
-			BasicUsername: bu,
-			BasicPassword: bp,
-			BearerToken:   ExtractBearerToken(r),
-			Impersonate:   ExtractImpersonation(r),
+			BasicUsername:       bu,
+			BasicPassword:       bp,
+			BearerToken:         ExtractBearerToken(r),
+			Impersonate:         ExtractImpersonation(r),
+			AuthenticatingProxy: ExtractAuthenticatingProxy(r),
 		})))
 	})
 }
@@ -160,10 +234,11 @@ func WebsocketInit(ctx context.Context, initPayload transport.InitPayload) (cont
 	}
 	bu, bp, _ := r.BasicAuth()
 	return context.WithValue(ctx, key, Credentials{
-		BasicUsername: bu,
-		BasicPassword: bp,
-		BearerToken:   ExtractBearerToken(r),
-		Impersonate:   ExtractImpersonation(r),
+		BasicUsername:       bu,
+		BasicPassword:       bp,
+		BearerToken:         ExtractBearerToken(r),
+		Impersonate:         ExtractImpersonation(r),
+		AuthenticatingProxy: ExtractAuthenticatingProxy(r),
 	}), nil
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -180,6 +180,11 @@ func ExtractImpersonation(r *http.Request) Impersonation {
 // ExtractAuthenticatingProxy extracts the user info from the HTTP headers set
 // by an authenticating proxy (if any).
 func ExtractAuthenticatingProxy(r *http.Request) AuthenticatingProxy {
+	// if client did not authenticate using a certificate, proxied user info
+	// will not be relayed.
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return AuthenticatingProxy{}
+	}
 	extra := make(map[string][]string)
 	for k, v := range r.Header {
 		if !strings.HasPrefix(k, headerPrefixXRemoteExtra) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
 )
 
 func TestCredentialsInject(t *testing.T) {
@@ -34,6 +35,11 @@ func TestCredentialsInject(t *testing.T) {
 	impGroup := "impish"
 	impExtraKey := "Coolness"
 	impExtraVal := "very"
+
+	proxiedUser := "proxied-user"
+	proxiedGroup := "proxied-group"
+	proxiedExtraKey := "Proxied-Extra-Key"
+	proxiedExtraVal := "proxied-extra-val"
 
 	cases := map[string]struct {
 		creds Credentials
@@ -50,6 +56,11 @@ func TestCredentialsInject(t *testing.T) {
 					Groups:   []string{impGroup},
 					Extra:    map[string][]string{impExtraKey: {impExtraVal}},
 				},
+				AuthenticatingProxy: AuthenticatingProxy{
+					Username: proxiedUser,
+					Groups:   []string{proxiedGroup},
+					Extra:    map[string][]string{proxiedExtraKey: {proxiedExtraVal}},
+				},
 			},
 			cfg: &rest.Config{},
 			want: &rest.Config{
@@ -61,6 +72,14 @@ func TestCredentialsInject(t *testing.T) {
 					Groups:   []string{impGroup},
 					Extra:    map[string][]string{impExtraKey: {impExtraVal}},
 				},
+				WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
+					return &authenticatingProxyTransport{
+						RoundTripper: rt,
+						username:     proxiedUser,
+						groups:       []string{proxiedGroup},
+						extra:        map[string][]string{proxiedExtraKey: {proxiedExtraVal}},
+					}
+				},
 			},
 		},
 	}
@@ -68,8 +87,107 @@ func TestCredentialsInject(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.creds.Inject(tc.cfg)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.Comparer(transportWrapperComparer)); diff != "" {
 				t.Errorf("\nc.Inject(...): -want, +got\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAuthenticatingProxyTransportRoundTrip(t *testing.T) {
+	proxiedUser := "proxied-user"
+	proxiedGroup := "proxied-group"
+	proxiedExtraKey := "Proxied-Extra-Key"
+	proxiedExtraVal := "proxied-extra-val"
+
+	type args struct {
+		username string
+		groups   []string
+		extra    map[string][]string
+	}
+	type want struct {
+		headers http.Header
+	}
+	tests := map[string]struct {
+		args args
+		want want
+	}{
+		"WithUsername": {
+			args: args{
+				username: proxiedUser,
+			},
+			want: want{
+				headers: headers(headerXRemoteUser, proxiedUser),
+			},
+		},
+		"WithGroups": {
+			args: args{
+				groups: []string{proxiedGroup},
+			},
+			want: want{
+				headers: headers(headerXRemoteGroup, proxiedGroup),
+			},
+		},
+		"WithExtra": {
+			args: args{
+				extra: map[string][]string{
+					proxiedExtraKey: {proxiedExtraVal},
+				},
+			},
+			want: want{
+				headers: headers(headerPrefixXRemoteExtra+proxiedExtraKey, proxiedExtraVal),
+			},
+		},
+		"WithAllFields": {
+			args: args{
+				username: proxiedUser,
+				groups:   []string{proxiedGroup},
+				extra: map[string][]string{
+					proxiedExtraKey: {proxiedExtraVal},
+				},
+			},
+			want: want{
+				headers: headers(headerXRemoteUser, proxiedUser, headerXRemoteGroup, proxiedGroup, headerPrefixXRemoteExtra+proxiedExtraKey, proxiedExtraVal),
+			},
+		},
+		"WithNoFields": {
+			want: want{
+				headers: headers(),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// we use a mock RoundTripper to make sure the wrapped RoundTripper
+			// by authenticatingProxyTransport is actually called and
+			// to capture the modified request by the
+			// authenticatingProxyTransport.
+			var modifiedReq *http.Request
+			mockRT := &mockRoundTripper{
+				fn: func(req *http.Request) (*http.Response, error) {
+					modifiedReq = req.Clone(req.Context())
+					return &http.Response{StatusCode: http.StatusOK}, nil
+				},
+			}
+
+			tp := &authenticatingProxyTransport{
+				RoundTripper: mockRT,
+				username:     tc.args.username,
+				groups:       tc.args.groups,
+				extra:        tc.args.extra,
+			}
+
+			resp, err := tp.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			if err != nil {
+				t.Fatalf("Unexpected error from RoundTripper: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected HTTP status OK, got: %v", resp.StatusCode)
+			}
+
+			if diff := cmp.Diff(tc.want.headers, modifiedReq.Header); diff != "" {
+				t.Errorf("authenticatingProxyTransport.RoundTrip(...): -want headers, +got headers: \n%s", diff)
 			}
 		})
 	}
@@ -81,7 +199,7 @@ func TestCredentialsHash(t *testing.T) {
 		extra []byte
 		want  string
 	}{
-		"CredsOnly": {
+		"TokenAndBasicCredentialsWithImpersonation": {
 			creds: Credentials{
 				BearerToken:   "toke-one",
 				BasicUsername: "so",
@@ -100,6 +218,41 @@ func TestCredentialsHash(t *testing.T) {
 			},
 			extra: []byte("coolness"),
 			want:  "2d0c7f73540de525665793bb7a8c970ecaaf4c8f9a08920327819803648e4006",
+		},
+		"ProxiedUserInfoWithImpersonation": {
+			creds: Credentials{
+				AuthenticatingProxy: AuthenticatingProxy{
+					Username: "proxied-user",
+					Groups:   []string{"proxied-group"},
+					Extra:    map[string][]string{"proxied-extra-key": {"proxied-extra-val"}},
+				},
+				Impersonate: Impersonation{
+					Username: "imp",
+					Groups:   []string{"imps"},
+					Extra:    map[string][]string{"coolness": {"very"}},
+				},
+			},
+			want: "f3f55d5e1159455dc5a0f4dc653e224f7bcf6a767d8e7d99c4922a32a815aeea",
+		},
+		"ProxiedUserInfoWithoutImpersonation": {
+			creds: Credentials{
+				AuthenticatingProxy: AuthenticatingProxy{
+					Username: "proxied-user",
+					Groups:   []string{"proxied-group"},
+					Extra:    map[string][]string{"proxied-extra-key": {"proxied-extra-val"}},
+				},
+			},
+			want: "9c5e23697eb3b66248ff1597814e63ecba45a3c6a659a185fb134d4e932cbb3d",
+		},
+		"ProxiedMultipleGroupsWithoutImpersonation": {
+			creds: Credentials{
+				AuthenticatingProxy: AuthenticatingProxy{
+					Username: "proxied-user",
+					Groups:   []string{"proxied-group", "secondary-group"},
+					Extra:    map[string][]string{"proxied-extra-key": {"proxied-extra-val"}},
+				},
+			},
+			want: "643e511e33078236e00523e5505283b798c85f5dbf2b756a6f710714ded1a2d7",
 		},
 	}
 
@@ -124,6 +277,11 @@ func TestMiddleware(t *testing.T) {
 	impGroup := "impish"
 	impExtraKey := "Coolness"
 	impExtraVal := "very"
+
+	proxiedUser := "proxied-user"
+	proxiedGroup := "proxied-group"
+	proxiedExtraKey := "Proxied-Extra-Key"
+	proxiedExtraVal := "proxied-extra-val"
 
 	type want struct {
 		c  Credentials
@@ -175,6 +333,69 @@ func TestMiddleware(t *testing.T) {
 						Username: impUser,
 						Groups:   []string{impGroup},
 						Extra:    map[string][]string{impExtraKey: {impExtraVal}},
+					},
+				},
+				ok: true,
+			},
+		},
+		"WithProxiedUserInfo": {
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/", nil)
+				r.Header.Add(headerXRemoteUser, proxiedUser)
+				r.Header.Add(headerXRemoteGroup, proxiedGroup)
+				r.Header.Add(headerPrefixXRemoteExtra+proxiedExtraKey, proxiedExtraVal)
+				return r
+			}(),
+			want: want{
+				c: Credentials{
+					AuthenticatingProxy: AuthenticatingProxy{
+						Username: proxiedUser,
+						Groups:   []string{proxiedGroup},
+						Extra:    map[string][]string{proxiedExtraKey: {proxiedExtraVal}},
+					},
+				},
+				ok: true,
+			},
+		},
+		"WithProxiedUserInfoWithImpersonation": {
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/", nil)
+				r.Header.Add(headerXRemoteUser, proxiedUser)
+				r.Header.Add(headerXRemoteGroup, proxiedGroup)
+				r.Header.Add(headerPrefixXRemoteExtra+proxiedExtraKey, proxiedExtraVal)
+
+				r.Header.Add(headerImpersonateUser, impUser)
+				r.Header.Add(headerImpersonateGroup, impGroup)
+				r.Header.Add(headerPrefixImpersonateExtra+impExtraKey, impExtraVal)
+
+				return r
+			}(),
+			want: want{
+				c: Credentials{
+					AuthenticatingProxy: AuthenticatingProxy{
+						Username: proxiedUser,
+						Groups:   []string{proxiedGroup},
+						Extra:    map[string][]string{proxiedExtraKey: {proxiedExtraVal}},
+					},
+					Impersonate: Impersonation{
+						Username: impUser,
+						Groups:   []string{impGroup},
+						Extra:    map[string][]string{impExtraKey: {impExtraVal}},
+					},
+				},
+				ok: true,
+			},
+		},
+		"WithProxiedUserInfoOnlyUsername": {
+			r: func() *http.Request {
+				r := httptest.NewRequest("GET", "/", nil)
+				r.Header.Add(headerXRemoteUser, proxiedUser)
+				return r
+			}(),
+			want: want{
+				c: Credentials{
+					AuthenticatingProxy: AuthenticatingProxy{
+						Username: proxiedUser,
 					},
 				},
 				ok: true,
@@ -268,4 +489,40 @@ func TestFromContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+func authnProxyTransportComparer(apt1 *authenticatingProxyTransport, apt2 *authenticatingProxyTransport) bool {
+	return apt1.username == apt2.username && cmp.Equal(apt1.groups, apt2.groups) && cmp.Equal(apt1.extra, apt2.extra) && cmp.Equal(apt1.RoundTripper, apt2.RoundTripper)
+}
+
+func transportWrapperComparer(w1 transport.WrapperFunc, w2 transport.WrapperFunc) bool {
+	if w1 == nil && w2 == nil {
+		return true
+	}
+	if w1 == nil || w2 == nil {
+		return false
+	}
+
+	rt1 := w1(nil)
+	rt2 := w2(nil)
+	if diff := cmp.Diff(rt1, rt2, cmp.Comparer(authnProxyTransportComparer)); diff != "" {
+		return false
+	}
+	return true
+}
+
+func headers(kv ...string) http.Header {
+	h := make(http.Header, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		h[kv[i]] = append(h[kv[i]], kv[i+1])
+	}
+	return h
+}
+
+type mockRoundTripper struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.fn(req)
 }

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -42,7 +42,6 @@ const (
 	errNewClient        = "cannot create new write client"
 	errNewCache         = "cannot create new read cache"
 	errNewHTTPClient    = "cannot create new HTTP client"
-	errDelegClient      = "cannot create cache-backed client"
 	errWaitForCacheSync = "cannot sync client cache"
 )
 
@@ -96,6 +95,17 @@ func RESTMapper(cfg *rest.Config, httpClient *http.Client) (meta.RESTMapper, err
 // details and credentials removed.
 func Anonymize(cfg *rest.Config) *rest.Config {
 	return rest.AnonymousClientConfig(cfg)
+}
+
+// InjectClientTLSCredentials injects the specified TLS client key and
+// certificate to be used when establishing connections to the API server.
+// If either keyFile or certFile is an empty string, cfg is not modified.
+func InjectClientTLSCredentials(cfg *rest.Config, keyFile, certFile string) {
+	if len(keyFile) == 0 || len(certFile) == 0 {
+		return
+	}
+	cfg.KeyFile = keyFile
+	cfg.CertFile = certFile
 }
 
 // TODO(negz): There are a few gotchas with watch based caches. The chief issue


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This PR adds support for authenticating against the API server using the proxied user information set by an authenticating proxy. The headers set by the authenticating proxy are currently not parameterized and they are expected to be `X-Remote-User`, `X-Remote-Group` and `X-Remote-Extra-`. Currently, xgql does not authenticate the incoming request itself.

When using proxied user information, xgql needs to make requests to the API server using a TLS client certificate. The certificate and the key to be used can optionally be specified via the newly added `--tls-client-cert` and `--tls-client-key` command-line options, respectively. For backwards-compatibility purposes, these two parameters are both optional.

The PR also adds another optional command-line argument `client-ca-bundle`, which will be used to configure the client CA bundle to be used if the xgql client sends a TLS certificate during the handshake. It's optional for a client to send a client cert when making a request to xgql (for not breaking existing clients) _but a client must authenticate itself using a client certificate in order to have xgql route the proxied user information via the `X-Remote-*` headers to the API server._

The proposed plan is to roll out support for authenticating proxy in xgql across Cloud Spaces with the new features turned off. When we are removing mxp-gateway from Spaces, we will enable the new features via the (internal) xgql Helm chart shipped in Spaces and spaces-router will start routing requests directly to xgql, without going through mxp-gateway.

I have:

- [x] Add mTLS support for xgql as a prerequisite for relaying proxied user information.
- [x] Test the `--client-ca-bundle` command-line option for backwards-compatibility.
- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Did some manual tests using connected Spaces.
