### PR TITLE
Do not extend cache on every request

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -231,10 +231,7 @@ func (c *Cache) Get(cr auth.Credentials, o ...GetOption) (client.Client, error) 
 	c.mx.RUnlock()
 
 	if ok {
-		log.Debug("Used existing cached client",
-			"new-expiry", time.Now().Add(c.expiry),
-		)
-		sn.expiration.Reset(c.expiry)
+		log.Debug("Used existing cached client")
 		return sn.client, nil
 	}
 


### PR DESCRIPTION
### Description of your changes

We are caching clients with an expiry (default 30 mins). If a cilent is reused from the cache, we are extending the expiration by the expiry time.

Right now, we think that is causing xgql to extend the expiration of clients with expired tokens (seems likely) and resulting in failed requests for the same clients.

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
