### PR TITLE
Watch for cert changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -80,6 +80,8 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: ${{ env.GOLANGCI_VERSION }}
+          # We install our own Go version, so we don't need to install it here.
+          skip-go-installation: true
 
   check-diff:
     runs-on: ubuntu-latest
@@ -324,7 +326,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
           AWS_DEFAULT_REGION: us-west-2
-      
+
       - name: Publish Schema
         if: github.ref == 'refs/heads/main' && env.APOLLO_KEY != ''
         run: yarn run push-schema upbound-xgql@main

--- a/cmd/xgql/main.go
+++ b/cmd/xgql/main.go
@@ -24,8 +24,10 @@ import (
 	stdlog "log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 
 	// NOTE(tnthornton) we are making an active choice to have a pprof endpoint
@@ -62,6 +64,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -305,6 +308,9 @@ func main() { //nolint:gocyclo
 	kingpin.FatalIfError(startHealth(internal.HealthOptions{Health: *health, HealthPort: *healthPort}, log), "cannot start health endpoints")
 
 	if *tlsCert != "" && *tlsKey != "" {
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
 		srv := &http.Server{
 			Addr:              *listen,
 			Handler:           rt,
@@ -313,21 +319,48 @@ func main() { //nolint:gocyclo
 			ReadHeaderTimeout: 5 * time.Second,
 			ErrorLog:          stdlog.New(io.Discard, "", 0),
 		}
+
+		tlsConfig := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+
+		// If client CA bundle provided, add client auth config
 		if len(*clientCABundle) > 0 {
 			p, err := getCertPool(*clientCABundle)
-			if err != nil {
-				kingpin.FatalIfError(err, "cannot initialize the client CA pool from the specified bundle %s", *clientCABundle)
-			}
-			srv.TLSConfig = &tls.Config{
-				ClientAuth: tls.VerifyClientCertIfGiven,
-				ClientCAs:  p,
-				MinVersion: tls.VersionTLS12,
-			}
+			kingpin.FatalIfError(err, "cannot initialize the client CA pool from the specified bundle %s", *clientCABundle)
+			tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
+			tlsConfig.ClientCAs = p
 		}
+
+		srv.TLSConfig = tlsConfig
+
+		// Setup cert watcher for dynamic cert reload
+		watcher, err := certwatcher.New(*tlsCert, *tlsKey)
+		kingpin.FatalIfError(err, "cannot create cert watcher")
+
+		go func() {
+			kingpin.FatalIfError(watcher.Start(ctx), "cannot start cert watcher")
+		}()
+
+		// Use watcher to get certificate dynamically
+		srv.TLSConfig.GetCertificate = watcher.GetCertificate
+
 		go func() {
 			log.Debug("Listening for TLS connections", "address", *listen)
-			kingpin.FatalIfError(srv.ListenAndServeTLS(*tlsCert, *tlsKey), "cannot serve TLS HTTP")
+			err := srv.ListenAndServeTLS("", "")
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				kingpin.FatalIfError(err, "cannot serve TLS HTTP")
+			}
 		}()
+
+		<-ctx.Done()
+		log.Debug("Shutting down server...")
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		kingpin.FatalIfError(srv.Shutdown(shutdownCtx), "cannot shutdown server gracefully")
+		return
 	}
 
 	log.Debug("Listening for insecure connections", "address", *insecure)


### PR DESCRIPTION
### Description of your changes

This PR adjusts xgql to use the certwatcher and reload certs when they change.

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

built the image and loaded it into cloud spaces local dev

after deleting the cert secret, i saw xgql reload it (with debug logs enabled)

```
2025-09-10T20:34:10Z	DEBUG	controller-runtime.certwatcher	certificate event	{"event": "CHMOD         \"/etc/certs/xgql/tls.key\""}
2025-09-10T20:34:10Z	INFO	controller-runtime.certwatcher	Updated current TLS certificate
2025-09-10T20:34:10Z	DEBUG	controller-runtime.certwatcher	certificate event	{"event": "REMOVE        \"/etc/certs/xgql/tls.key\""}
2025-09-10T20:34:10Z	INFO	controller-runtime.certwatcher	Updated current TLS certificate
2025-09-10T20:34:10Z	DEBUG	controller-runtime.certwatcher	certificate event	{"event": "CHMOD         \"/etc/certs/xgql/tls.crt\""}
2025-09-10T20:34:10Z	INFO	controller-runtime.certwatcher	Updated current TLS certificate
2025-09-10T20:34:10Z	DEBUG	controller-runtime.certwatcher	certificate event	{"event": "REMOVE        \"/etc/certs/xgql/tls.crt\""}
2025-09-10T20:34:10Z	INFO	controller-runtime.certwatcher	Updated current TLS certificate
2025-09-10T20:34:10Z	DEBUG	xgql	Handled request	{"id": "", "method": "GET", "tls": false, "host": "192.168.2.113:8088", "uri": "/readyz", "protocol": "HTTP/1.1", "remote": "192.168.2.58:46538", "status": 200, "bytes": 0, "duration": "8.791µs"}
```